### PR TITLE
Backfill dashboard stats from media issue details and scan timestamps

### DIFF
--- a/backend/app/api/media.py
+++ b/backend/app/api/media.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import selectinload
 
 from app.api.auth import get_current_user
 from app.models.database import get_db
-from app.models.entities import User, Show, Season, MediaFile, AudioTrack
+from app.models.entities import User, Show, Season, MediaFile, AudioTrack, ScanLocation
 from app.models.schemas import (
     AudioTrackResponse,
     ShowResponse,
@@ -25,6 +25,35 @@ from app.models.schemas import (
 )
 
 router = APIRouter()
+
+
+def _build_issue_predicate(*patterns: str):
+    """Build a SQL predicate that matches any known issue representation."""
+    return or_(*[MediaFile.issue_details.ilike(pattern) for pattern in patterns])
+
+
+def _media_user_scope_filters(current_user: User) -> list:
+    """Return media filters scoped to the current user when ownership fields exist."""
+    filters = []
+    if hasattr(MediaFile, "user_id"):
+        filters.append(MediaFile.user_id == current_user.id)
+    return filters
+
+
+def _show_user_scope_filters(current_user: User) -> list:
+    """Return show filters scoped to the current user when ownership fields exist."""
+    filters = []
+    if hasattr(Show, "user_id"):
+        filters.append(Show.user_id == current_user.id)
+    return filters
+
+
+def _scan_location_user_scope_filters(current_user: User) -> list:
+    """Return scan-location filters scoped to the current user when ownership fields exist."""
+    filters = []
+    if hasattr(ScanLocation, "user_id"):
+        filters.append(ScanLocation.user_id == current_user.id)
+    return filters
 
 
 def _build_audio_track_responses(audio_tracks: list) -> list[AudioTrackResponse]:
@@ -74,23 +103,62 @@ async def get_dashboard_stats(
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
     """Get dashboard statistics."""
-    total_titles = await db.scalar(select(func.count(Show.id))) or 0
+    show_scope_filters = _show_user_scope_filters(current_user)
+    media_scope_filters = _media_user_scope_filters(current_user)
+    scan_scope_filters = _scan_location_user_scope_filters(current_user)
+
+    total_titles = await db.scalar(select(func.count(Show.id)).where(*show_scope_filters)) or 0
 
     movie_count = await db.scalar(
-        select(func.count(Show.id)).where(Show.media_type == "movie")
+        select(func.count(Show.id)).where(*show_scope_filters, Show.media_type == "movie")
     ) or 0
     tv_count = await db.scalar(
-        select(func.count(Show.id)).where(Show.media_type == "tv")
+        select(func.count(Show.id)).where(*show_scope_filters, Show.media_type == "tv")
     ) or 0
     anime_count = await db.scalar(
-        select(func.count(Show.id)).where(Show.media_type == "anime")
+        select(func.count(Show.id)).where(*show_scope_filters, Show.media_type == "anime")
     ) or 0
 
-    total_files = await db.scalar(select(func.count(MediaFile.id))) or 0
+    total_files = await db.scalar(select(func.count(MediaFile.id)).where(*media_scope_filters)) or 0
 
     files_with_issues = await db.scalar(
-        select(func.count(MediaFile.id)).where(MediaFile.has_issues == True)
+        select(func.count(MediaFile.id)).where(*media_scope_filters, MediaFile.has_issues == True)
     ) or 0
+
+    missing_english_predicate = _build_issue_predicate(
+        "%Missing English audio track%",
+        "%Missing English audio for dual audio (anime)%",
+        "%missing_english%",
+    )
+    missing_japanese_predicate = _build_issue_predicate(
+        "%Missing Japanese audio track (anime)%",
+        "%Missing Japanese audio for dual audio (anime)%",
+        "%missing_japanese%",
+    )
+    missing_dual_audio_predicate = _build_issue_predicate(
+        "%Missing dual audio (English + Japanese) for anime%",
+        "%Missing English audio for dual audio (anime)%",
+        "%Missing Japanese audio for dual audio (anime)%",
+        "%missing_dual_audio%",
+    )
+
+    missing_english_count = await db.scalar(
+        select(func.count(MediaFile.id)).where(*media_scope_filters, missing_english_predicate)
+    ) or 0
+    missing_japanese_count = await db.scalar(
+        select(func.count(MediaFile.id)).where(*media_scope_filters, missing_japanese_predicate)
+    ) or 0
+    missing_dual_audio_count = await db.scalar(
+        select(func.count(MediaFile.id)).where(*media_scope_filters, missing_dual_audio_predicate)
+    ) or 0
+
+    last_scan = await db.scalar(
+        select(func.max(ScanLocation.last_scanned)).where(*scan_scope_filters)
+    )
+    if last_scan is None:
+        last_scan = await db.scalar(
+            select(func.max(MediaFile.last_scanned)).where(*media_scope_filters)
+        )
 
     return DashboardStats(
         total_titles=total_titles,
@@ -99,10 +167,10 @@ async def get_dashboard_stats(
         movie_count=movie_count,
         tv_count=tv_count,
         anime_count=anime_count,
-        missing_english_count=0,
-        missing_japanese_count=0,
-        missing_dual_audio_count=0,
-        last_scan=None,
+        missing_english_count=missing_english_count,
+        missing_japanese_count=missing_japanese_count,
+        missing_dual_audio_count=missing_dual_audio_count,
+        last_scan=last_scan,
     )
 
 

--- a/backend/tests/test_media_stats.py
+++ b/backend/tests/test_media_stats.py
@@ -1,0 +1,171 @@
+from datetime import datetime, timezone
+import asyncio
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.api.media import get_dashboard_stats
+from app.models.entities import Base, MediaFile, ScanLocation, Show, User
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _build_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    session = session_factory()
+    return engine, session
+
+
+def test_dashboard_stats_issue_counters_and_last_scan_from_locations():
+    async def _test():
+        engine, session = await _build_session()
+        try:
+            shows = [
+                Show(title="Movie A", media_type="movie", is_anime=False),
+                Show(title="TV A", media_type="tv", is_anime=False),
+                Show(title="Anime A", media_type="anime", is_anime=True),
+            ]
+            session.add_all(shows)
+
+            media_files = [
+                MediaFile(
+                    file_path="/tmp/a1.mkv",
+                    filename="a1.mkv",
+                    file_size=10,
+                    last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    last_scanned=datetime(2024, 1, 2, tzinfo=timezone.utc),
+                    has_issues=True,
+                    issue_details="Missing English audio track",
+                ),
+                MediaFile(
+                    file_path="/tmp/a2.mkv",
+                    filename="a2.mkv",
+                    file_size=11,
+                    last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    last_scanned=datetime(2024, 1, 3, tzinfo=timezone.utc),
+                    has_issues=True,
+                    issue_details="Missing Japanese audio track (anime)",
+                ),
+                MediaFile(
+                    file_path="/tmp/a3.mkv",
+                    filename="a3.mkv",
+                    file_size=12,
+                    last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    last_scanned=datetime(2024, 1, 4, tzinfo=timezone.utc),
+                    has_issues=True,
+                    issue_details="Missing English audio for dual audio (anime)",
+                ),
+                MediaFile(
+                    file_path="/tmp/a4.mkv",
+                    filename="a4.mkv",
+                    file_size=13,
+                    last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    last_scanned=datetime(2024, 1, 5, tzinfo=timezone.utc),
+                    has_issues=True,
+                    issue_details="Missing Japanese audio for dual audio (anime)",
+                ),
+                MediaFile(
+                    file_path="/tmp/a5.mkv",
+                    filename="a5.mkv",
+                    file_size=14,
+                    last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    last_scanned=datetime(2024, 1, 6, tzinfo=timezone.utc),
+                    has_issues=True,
+                    issue_details="Missing dual audio (English + Japanese) for anime",
+                ),
+                MediaFile(
+                    file_path="/tmp/a6.mkv",
+                    filename="a6.mkv",
+                    file_size=15,
+                    last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    last_scanned=datetime(2024, 1, 7, tzinfo=timezone.utc),
+                    has_issues=False,
+                    issue_details=None,
+                ),
+            ]
+            session.add_all(media_files)
+
+            session.add_all(
+                [
+                    ScanLocation(
+                        path="/media/a",
+                        label="A",
+                        media_type="tv",
+                        last_scanned=datetime(2024, 2, 1, tzinfo=timezone.utc),
+                    ),
+                    ScanLocation(
+                        path="/media/b",
+                        label="B",
+                        media_type="anime",
+                        last_scanned=datetime(2024, 2, 5, tzinfo=timezone.utc),
+                    ),
+                ]
+            )
+            await session.commit()
+
+            current_user = User(
+                id=1,
+                plex_user_id="u1",
+                plex_username="tester",
+                plex_token="token",
+            )
+            stats = await get_dashboard_stats(current_user=current_user, db=session)
+
+            assert stats.total_titles == 3
+            assert stats.total_files == 6
+            assert stats.total_files_with_issues == 5
+            assert stats.movie_count == 1
+            assert stats.tv_count == 1
+            assert stats.anime_count == 1
+            assert stats.missing_english_count == 2
+            assert stats.missing_japanese_count == 2
+            assert stats.missing_dual_audio_count == 3
+            assert stats.last_scan == datetime(2024, 2, 5)
+        finally:
+            await session.close()
+            await engine.dispose()
+
+    _run(_test())
+
+
+def test_dashboard_stats_last_scan_falls_back_to_media_files():
+    async def _test():
+        engine, session = await _build_session()
+        try:
+            session.add(
+                MediaFile(
+                    file_path="/tmp/b1.mkv",
+                    filename="b1.mkv",
+                    file_size=20,
+                    last_modified=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    last_scanned=datetime(2024, 3, 10, tzinfo=timezone.utc),
+                    has_issues=False,
+                    issue_details=None,
+                )
+            )
+            await session.commit()
+
+            current_user = User(
+                id=2,
+                plex_user_id="u2",
+                plex_username="tester2",
+                plex_token="token",
+            )
+            stats = await get_dashboard_stats(current_user=current_user, db=session)
+
+            assert stats.last_scan == datetime(2024, 3, 10)
+            assert stats.total_files == 1
+        finally:
+            await session.close()
+            await engine.dispose()
+
+    _run(_test())


### PR DESCRIPTION
### Motivation
- Dashboard placeholders needed real, query-backed counts for common audio-issue cases and an accurate `last_scan` value. 
- Counters should derive from stored `MediaFile.issue_details` (or equivalent structured storage) using explicit predicates for English/Japanese/dual-audio missing cases. 
- `last_scan` should come from scan-location timestamps when available and fall back to media-file scan timestamps. 
- Stats must be ready to honor per-user scoping once ownership columns are added.

### Description
- Replaced placeholder dashboard counters in `get_dashboard_stats` with SQL queries that count `MediaFile` rows and compute issue counters via explicit predicates that match the various "missing audio" issue messages. (`backend/app/api/media.py`) 
- Added helper predicates and functions: `_build_issue_predicate`, `_media_user_scope_filters`, `_show_user_scope_filters`, and `_scan_location_user_scope_filters` to centralize issue matching and optionally apply user-scoping when `user_id` columns exist. (`backend/app/api/media.py`) 
- Compute `last_scan` as `max(ScanLocation.last_scanned)` (scoped to the user when applicable) and fall back to `max(MediaFile.last_scanned)` if no scan-location timestamps exist. (`backend/app/api/media.py`) 
- Added automated tests exercising mixed fixtures that verify each issue counter and both `last_scan` behaviors in `backend/tests/test_media_stats.py`.

### Testing
- Ran the backend test suite with `cd backend && pytest -q`, which executed the new tests in `backend/tests/test_media_stats.py`. 
- Result: `2 passed` with `1 warning` (the warning is from config defaults); both new tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c5b03798832f866053b7ce4cee5c)