### PR TITLE
Centralize scan coordination in async ScanStateManager

### DIFF
--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,15 +1,17 @@
 """Core business logic package."""
 
-from app.core.scanner import MediaScanner, run_scan, cancel_current_scan
+from app.core.scanner import MediaScanner, run_scan
 from app.core.analyzer import AudioAnalyzer
 from app.core.plex_connector import PlexConnector
 from app.core.preference_engine import PreferenceEngine
+from app.core.scan_state import scan_state_manager, ScanStateManager
 
 __all__ = [
     "MediaScanner",
     "run_scan",
-    "cancel_current_scan",
     "AudioAnalyzer",
     "PlexConnector",
     "PreferenceEngine",
+    "ScanStateManager",
+    "scan_state_manager",
 ]

--- a/backend/app/core/scan_state.py
+++ b/backend/app/core/scan_state.py
@@ -1,0 +1,83 @@
+"""Centralized scan state management."""
+
+import asyncio
+from datetime import datetime, timezone
+
+from app.models.schemas import ScanStatus
+
+
+class ScanStateManager:
+    """Owns scan status and cancellation state for coordination across modules."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._status = ScanStatus(is_running=False)
+        self._cancel_requested = False
+
+    async def get_status(self) -> ScanStatus:
+        """Return a safe copy of the current scan status."""
+        async with self._lock:
+            return self._status.model_copy(deep=True)
+
+    async def start_scan(self) -> ScanStatus | None:
+        """Transition to running state, returning None if already running."""
+        async with self._lock:
+            if self._status.is_running:
+                return None
+
+            self._cancel_requested = False
+            self._status = ScanStatus(
+                is_running=True,
+                current_location=None,
+                files_scanned=0,
+                files_total=0,
+                current_file=None,
+                started_at=datetime.now(timezone.utc),
+                errors=[],
+            )
+            return self._status.model_copy(deep=True)
+
+    async def cancel_scan(self) -> ScanStatus | None:
+        """Request cancellation for a running scan."""
+        async with self._lock:
+            if not self._status.is_running:
+                return None
+            self._cancel_requested = True
+            return self._status.model_copy(deep=True)
+
+    async def is_cancel_requested(self) -> bool:
+        """Check whether cancellation has been requested."""
+        async with self._lock:
+            return self._cancel_requested
+
+    async def update_status(self, **kwargs) -> ScanStatus:
+        """Update scan status fields and return a copy of the new state."""
+        async with self._lock:
+            current = self._status.model_dump()
+            current.update(kwargs)
+            self._status = ScanStatus(**current)
+            return self._status.model_copy(deep=True)
+
+    async def append_error(self, error: str) -> ScanStatus:
+        """Append an error message to scan status."""
+        async with self._lock:
+            self._status.errors.append(error)
+            return self._status.model_copy(deep=True)
+
+    async def finish_scan(self) -> ScanStatus:
+        """Transition to not running while keeping progress context."""
+        async with self._lock:
+            self._cancel_requested = False
+            self._status.is_running = False
+            self._status.current_location = None
+            self._status.current_file = None
+            return self._status.model_copy(deep=True)
+
+    async def reset(self) -> None:
+        """Reset state for tests."""
+        async with self._lock:
+            self._cancel_requested = False
+            self._status = ScanStatus(is_running=False)
+
+
+scan_state_manager = ScanStateManager()

--- a/backend/tests/test_scan_state.py
+++ b/backend/tests/test_scan_state.py
@@ -1,0 +1,54 @@
+"""Unit tests for centralized scan state transitions."""
+
+import unittest
+
+from app.core.scan_state import ScanStateManager
+
+
+class ScanStateManagerTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.manager = ScanStateManager()
+
+    async def test_start_scan_transitions_to_running(self) -> None:
+        started = await self.manager.start_scan()
+
+        self.assertIsNotNone(started)
+        self.assertTrue(started.is_running)
+        self.assertEqual(started.files_scanned, 0)
+        self.assertEqual(started.files_total, 0)
+        self.assertFalse(await self.manager.is_cancel_requested())
+
+    async def test_duplicate_start_is_rejected(self) -> None:
+        first = await self.manager.start_scan()
+        second = await self.manager.start_scan()
+
+        self.assertIsNotNone(first)
+        self.assertIsNone(second)
+
+    async def test_cancel_scan_transitions_when_running(self) -> None:
+        await self.manager.start_scan()
+
+        status = await self.manager.cancel_scan()
+
+        self.assertIsNotNone(status)
+        self.assertTrue(status.is_running)
+        self.assertTrue(await self.manager.is_cancel_requested())
+
+    async def test_status_updates_and_finish_scan(self) -> None:
+        await self.manager.start_scan()
+        await self.manager.update_status(current_location="/media/test", files_total=3, files_scanned=1)
+
+        status = await self.manager.get_status()
+        self.assertEqual(status.current_location, "/media/test")
+        self.assertEqual(status.files_total, 3)
+        self.assertEqual(status.files_scanned, 1)
+
+        finished = await self.manager.finish_scan()
+        self.assertFalse(finished.is_running)
+        self.assertIsNone(finished.current_location)
+        self.assertIsNone(finished.current_file)
+        self.assertFalse(await self.manager.is_cancel_requested())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Replace ad-hoc module-global scan state and mixed threading primitives with a single authoritative async-friendly manager to avoid races and inconsistent state handling.
- Ensure API endpoints and background scanner tasks share one consistent concurrency primitive and state transitions for start/cancel/status flows.
- Make cancellation, progress updates, and error reporting observable from a single source of truth to simplify coordination and testing.

### Description
- Added `backend/app/core/scan_state.py` implementing `ScanStateManager` that owns the `ScanStatus`, cancellation flag, and exposes `start_scan`, `cancel_scan`, `get_status`, `update_status`, `append_error`, `finish_scan`, and `reset` behind an `asyncio.Lock`.
- Updated scan API endpoints in `backend/app/api/scan.py` so `/status`, `/start`, and `/cancel` call `scan_state_manager` exclusively and no longer mutate module-global state.
- Refactored `backend/app/core/scanner.py` to remove legacy globals and threading lock, and to use `scan_state_manager` for status updates, error appends, cancellation checks, and final cleanup.
- Updated `backend/app/core/__init__.py` exports to include the new manager and added `backend/tests/test_scan_state.py` with async unit tests for start/duplicate-start/cancel/status/finish transitions.

### Testing
- Ran unit tests with `PYTHONPATH=backend python -m unittest discover -s backend/tests -v` which executed 4 tests and all passed (`OK`).
- Verified code compiles with `python -m compileall backend/app backend/tests` with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c5af3b90832fa1bb2f03b3213a8b)