### PR TITLE
Enforce strict scan-location validation and return consistent 400s

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,8 +3,10 @@
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.config import get_settings
@@ -44,6 +46,23 @@ app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])
 app.include_router(scan.router, prefix="/api/scan", tags=["Scanning"])
 app.include_router(media.router, prefix="/api/media", tags=["Media"])
 app.include_router(settings_router.router, prefix="/api/settings", tags=["Settings"])
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_exception_handler(request: Request, exc: RequestValidationError):
+    """Return consistent 400 errors with actionable validation messages."""
+    messages = []
+    for error in exc.errors():
+        location = " -> ".join(str(part) for part in error.get("loc", []))
+        messages.append(f"{location}: {error.get('msg', 'Invalid input')}")
+
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        content={
+            "detail": "Invalid request input.",
+            "errors": messages,
+        },
+    )
 
 
 @app.get("/api/health")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/backend/tests/test_scan_validation.py
+++ b/backend/tests/test_scan_validation.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from app.api.auth import get_current_user
+from app.api.scan import _validate_scan_media_type
+from app.main import app
+from app.models.database import get_db
+
+
+class DummySession:
+    async def execute(self, *args, **kwargs):
+        raise AssertionError("DB should not be called for invalid payload validation")
+
+
+async def override_get_db():
+    yield DummySession()
+
+
+async def override_get_current_user():
+    return SimpleNamespace(plex_token="test-token")
+
+
+app.dependency_overrides[get_db] = override_get_db
+app.dependency_overrides[get_current_user] = override_get_current_user
+
+
+client = TestClient(app)
+
+
+def test_create_scan_location_invalid_media_type_returns_400():
+    response = client.post(
+        "/api/scan/locations",
+        json={
+            "path": "/media/library",
+            "label": "Library",
+            "media_type": "documentary",
+        },
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["detail"] == "Invalid request input."
+    assert any("media_type" in error for error in body["errors"])
+
+
+def test_create_scan_location_out_of_scope_path_returns_400():
+    response = client.post(
+        "/api/scan/locations",
+        json={
+            "path": "/tmp/library",
+            "label": "Library",
+            "media_type": "tv",
+        },
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["detail"] == "Invalid request input."
+    assert any("Path must be under /media." in error for error in body["errors"])
+
+
+def test_defensive_media_type_validator_rejects_invalid_value():
+    try:
+        _validate_scan_media_type("invalid")
+        assert False, "Expected HTTPException for invalid media type"
+    except HTTPException as exc:
+        assert exc.status_code == 400
+        assert "media_type must be one of: tv, movie, anime." in exc.detail


### PR DESCRIPTION
### Motivation

- Prevent invalid or out-of-scope scan locations from being persisted by enforcing stricter input rules for media type and paths.  
- Provide consistent, actionable HTTP 400 responses for request validation failures so clients get clear error messages.  

### Description

- Constrained scan location media types with a `ScanMediaType` enum (`tv`, `movie`, `anime`) and applied it to `ScanLocationCreate` and `ScanLocationUpdate` in `backend/app/models/schemas.py`.  
- Added a shared `validate_media_root_path` helper that requires absolute, normalized paths under `/media` and wired it into the `ScanLocationCreate.path` validator.  
- Added defensive validation in `backend/app/api/scan.py` to re-validate and normalize `path` and verify `media_type` before insert/update, and reused the path guard for the browse endpoint; invalid input raises consistent HTTP 400 `Invalid scan location input:` errors.  
- Added a FastAPI `RequestValidationError` handler in `backend/app/main.py` that returns HTTP 400 with a structured `errors` list and an overall `detail` of `Invalid request input.`.  
- Added tests under `backend/tests/` covering invalid media types, out-of-scope paths, and the defensive media-type validator, plus a test `conftest.py` helper to ensure imports work in the test environment.  

### Testing

- Ran the test suite with `cd backend && pytest -q`.  
- Result: `3 passed, 1 warning` (tests covering invalid media-type, out-of-scope path, and defensive validator all passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c5ae3d34832f9784057d5dbb36bc)