### PR TITLE
Harden scan path validation against prefix and symlink escapes

### DIFF
--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -36,6 +36,33 @@ def get_scan_state() -> ScanStatus:
     return _scan_state
 
 
+def resolve_media_path(path: str) -> Path:
+    """Resolve and validate a filesystem path under MEDIA_ROOT."""
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Path must be absolute",
+        )
+
+    try:
+        resolved = candidate.resolve()
+        media_root = Path(MEDIA_ROOT).resolve()
+        resolved.relative_to(media_root)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Path must be under /media/",
+        )
+    except OSError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid path",
+        )
+
+    return resolved
+
+
 # ============== Directory Browsing ==============
 
 
@@ -45,20 +72,7 @@ async def browse_directories(
     path: str = Query(MEDIA_ROOT, description="Directory path to browse"),
 ):
     """List subdirectories at the given path for scan location selection."""
-    # Resolve and validate the path is under media root
-    try:
-        resolved = Path(path).resolve()
-        media_root = Path(MEDIA_ROOT).resolve()
-        if not str(resolved).startswith(str(media_root)):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Path must be under /media/",
-            )
-    except (ValueError, OSError):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid path",
-        )
+    resolved = resolve_media_path(path)
 
     if not resolved.exists() or not resolved.is_dir():
         raise HTTPException(
@@ -106,9 +120,11 @@ async def create_scan_location(
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
     """Add a new scan location."""
+    resolved_path = str(resolve_media_path(location.path))
+
     # Check if path already exists
     result = await db.execute(
-        select(ScanLocation).where(ScanLocation.path == location.path)
+        select(ScanLocation).where(ScanLocation.path == resolved_path)
     )
     existing = result.scalar_one_or_none()
 
@@ -119,7 +135,7 @@ async def create_scan_location(
         )
 
     new_location = ScanLocation(
-        path=location.path,
+        path=resolved_path,
         label=location.label,
         media_type=location.media_type,
         enabled=location.enabled,

--- a/backend/tests/test_scan_path_validation.py
+++ b/backend/tests/test_scan_path_validation.py
@@ -1,0 +1,68 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from app.api import scan
+
+
+class ResolveMediaPathTests(unittest.TestCase):
+    def test_accepts_media_descendant(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            media_root = Path(tmp) / "media"
+            target = media_root / "shows"
+            target.mkdir(parents=True)
+
+            with patch.object(scan, "MEDIA_ROOT", str(media_root)):
+                resolved = scan.resolve_media_path(str(target))
+
+            self.assertEqual(resolved, target.resolve())
+
+    def test_rejects_media2_prefix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            media_root = Path(tmp) / "media"
+            media2 = Path(tmp) / "media2"
+            media_root.mkdir()
+            media2.mkdir()
+
+            with patch.object(scan, "MEDIA_ROOT", str(media_root)):
+                with self.assertRaises(HTTPException) as ctx:
+                    scan.resolve_media_path(str(media2))
+
+            self.assertEqual(ctx.exception.status_code, 400)
+            self.assertEqual(ctx.exception.detail, "Path must be under /media/")
+
+    def test_rejects_relative_traversal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            media_root = Path(tmp) / "media"
+            media_root.mkdir()
+
+            with patch.object(scan, "MEDIA_ROOT", str(media_root)):
+                with self.assertRaises(HTTPException) as ctx:
+                    scan.resolve_media_path("../media/shows")
+
+            self.assertEqual(ctx.exception.status_code, 400)
+            self.assertEqual(ctx.exception.detail, "Path must be absolute")
+
+    def test_rejects_symlink_escape(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            media_root = Path(tmp) / "media"
+            outside = Path(tmp) / "outside"
+            media_root.mkdir()
+            outside.mkdir()
+
+            link = media_root / "linked-outside"
+            link.symlink_to(outside, target_is_directory=True)
+
+            with patch.object(scan, "MEDIA_ROOT", str(media_root)):
+                with self.assertRaises(HTTPException) as ctx:
+                    scan.resolve_media_path(str(link))
+
+            self.assertEqual(ctx.exception.status_code, 400)
+            self.assertEqual(ctx.exception.detail, "Path must be under /media/")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Replace brittle string-prefix path checks with a canonical ancestry check to prevent `/media2`-style bypasses and symlink escapes.  
- Ensure endpoints that accept filesystem paths consistently enforce absolute paths and are normalized before use or persistence.  
- Add targeted tests to validate correct/incorrect inputs and symlink edge cases to prevent regressions.

### Description
- Add `resolve_media_path(path: str) -> Path` which enforces that inputs are absolute, resolves symlinks (`Path.resolve()`), and validates ancestry under `MEDIA_ROOT` using `Path.relative_to()`; it raises `HTTPException` for invalid inputs.  
- Replace the `startswith`-based root check in `browse_directories` with a call to `resolve_media_path`.  
- Canonicalize and validate paths passed to `create_scan_location` by resolving the provided path with `resolve_media_path` and store the resolved path in the database.  
- Add unit tests in `backend/tests/test_scan_path_validation.py` covering accepted `/media/...` descendants and rejected `/media2/...`, relative traversal (`..`/non-absolute), and symlink escape scenarios.

### Testing
- Ran the unit tests with `PYTHONPATH=backend python -m unittest discover -s backend/tests -v` and all added tests passed (4 tests, OK).  
- The test run completed successfully and validated the new path validation behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c5ad473c832fa596f0327f7573ec)