### PR TITLE
Enforce per-user ownership and isolation for media and scan data

### DIFF
--- a/backend/app/api/media.py
+++ b/backend/app/api/media.py
@@ -74,22 +74,28 @@ async def get_dashboard_stats(
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
     """Get dashboard statistics."""
-    total_titles = await db.scalar(select(func.count(Show.id))) or 0
+    total_titles = await db.scalar(
+        select(func.count(Show.id)).where(Show.user_id == current_user.id)
+    ) or 0
 
     movie_count = await db.scalar(
-        select(func.count(Show.id)).where(Show.media_type == "movie")
+        select(func.count(Show.id)).where(Show.media_type == "movie", Show.user_id == current_user.id)
     ) or 0
     tv_count = await db.scalar(
-        select(func.count(Show.id)).where(Show.media_type == "tv")
+        select(func.count(Show.id)).where(Show.media_type == "tv", Show.user_id == current_user.id)
     ) or 0
     anime_count = await db.scalar(
-        select(func.count(Show.id)).where(Show.media_type == "anime")
+        select(func.count(Show.id)).where(Show.media_type == "anime", Show.user_id == current_user.id)
     ) or 0
 
-    total_files = await db.scalar(select(func.count(MediaFile.id))) or 0
+    total_files = await db.scalar(
+        select(func.count(MediaFile.id)).where(MediaFile.user_id == current_user.id)
+    ) or 0
 
     files_with_issues = await db.scalar(
-        select(func.count(MediaFile.id)).where(MediaFile.has_issues == True)
+        select(func.count(MediaFile.id)).where(
+            MediaFile.has_issues == True, MediaFile.user_id == current_user.id
+        )
     ) or 0
 
     return DashboardStats(
@@ -124,19 +130,24 @@ async def list_shows(
     # Subqueries for season-based counts (TV/anime)
     season_count_sq = (
         select(Season.show_id, func.count(Season.id).label("season_count"))
+        .join(Show, Show.id == Season.show_id)
+        .where(Show.user_id == current_user.id)
         .group_by(Season.show_id)
         .subquery()
     )
     episode_count_sq = (
         select(Season.show_id, func.count(MediaFile.id).label("episode_count"))
         .join(MediaFile, MediaFile.season_id == Season.id)
+        .join(Show, Show.id == Season.show_id)
+        .where(Show.user_id == current_user.id, MediaFile.user_id == current_user.id)
         .group_by(Season.show_id)
         .subquery()
     )
     season_issues_sq = (
         select(Season.show_id, func.count(MediaFile.id).label("season_issues"))
         .join(MediaFile, MediaFile.season_id == Season.id)
-        .where(MediaFile.has_issues == True)
+        .join(Show, Show.id == Season.show_id)
+        .where(MediaFile.has_issues == True, Show.user_id == current_user.id, MediaFile.user_id == current_user.id)
         .group_by(Season.show_id)
         .subquery()
     )
@@ -147,7 +158,11 @@ async def list_shows(
             MediaFile.show_id,
             func.count(MediaFile.id).label("direct_file_count"),
         )
-        .where(MediaFile.show_id.isnot(None), MediaFile.season_id.is_(None))
+        .where(
+            MediaFile.show_id.isnot(None),
+            MediaFile.season_id.is_(None),
+            MediaFile.user_id == current_user.id,
+        )
         .group_by(MediaFile.show_id)
         .subquery()
     )
@@ -160,6 +175,7 @@ async def list_shows(
             MediaFile.show_id.isnot(None),
             MediaFile.season_id.is_(None),
             MediaFile.has_issues == True,
+            MediaFile.user_id == current_user.id,
         )
         .group_by(MediaFile.show_id)
         .subquery()
@@ -180,7 +196,7 @@ async def list_shows(
         .outerjoin(season_issues_sq, season_issues_sq.c.show_id == Show.id)
         .outerjoin(direct_file_count_sq, direct_file_count_sq.c.show_id == Show.id)
         .outerjoin(direct_issues_sq, direct_issues_sq.c.show_id == Show.id)
-    )
+    ).where(Show.user_id == current_user.id)
 
     # Apply filters
     filters = []
@@ -261,7 +277,7 @@ async def get_show(
             selectinload(Show.seasons),
             selectinload(Show.media_files).selectinload(MediaFile.audio_tracks),
         )
-        .where(Show.id == show_id)
+        .where(Show.id == show_id, Show.user_id == current_user.id)
     )
     show = result.scalar_one_or_none()
 
@@ -285,7 +301,10 @@ async def get_show(
                 func.count(MediaFile.id).label("episode_count"),
                 func.count(MediaFile.id).filter(MediaFile.has_issues == True).label("issues_count"),
             )
-            .where(MediaFile.season_id.in_(season_ids))
+            .where(
+                MediaFile.season_id.in_(season_ids),
+                MediaFile.user_id == current_user.id,
+            )
             .group_by(MediaFile.season_id)
         )
         for row in count_result.all():
@@ -335,7 +354,7 @@ async def update_show(
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
     """Update title properties."""
-    result = await db.execute(select(Show).where(Show.id == show_id))
+    result = await db.execute(select(Show).where(Show.id == show_id, Show.user_id == current_user.id))
     show = result.scalar_one_or_none()
 
     if not show:
@@ -364,11 +383,16 @@ async def update_show(
         select(func.count(Season.id)).where(Season.show_id == show.id)
     ) or 0
     episode_count = await db.scalar(
-        select(func.count(MediaFile.id)).join(Season).where(Season.show_id == show.id)
+        select(func.count(MediaFile.id)).join(Season).where(
+            Season.show_id == show.id,
+            MediaFile.user_id == current_user.id,
+        )
     ) or 0
     file_count = await db.scalar(
         select(func.count(MediaFile.id)).where(
-            MediaFile.show_id == show.id, MediaFile.season_id.is_(None)
+            MediaFile.show_id == show.id,
+            MediaFile.season_id.is_(None),
+            MediaFile.user_id == current_user.id,
         )
     ) or 0
     issues_count = await db.scalar(
@@ -378,6 +402,7 @@ async def update_show(
                 and_(MediaFile.show_id == show.id, MediaFile.season_id.is_(None)),
             ),
             MediaFile.has_issues == True,
+            MediaFile.user_id == current_user.id,
         )
     ) or 0
 
@@ -411,7 +436,11 @@ async def get_season(
     result = await db.execute(
         select(Season)
         .options(selectinload(Season.media_files).selectinload(MediaFile.audio_tracks))
-        .where(Season.show_id == show_id, Season.season_number == season_number)
+        .where(
+            Season.show_id == show_id,
+            Season.season_number == season_number,
+            Season.show.has(Show.user_id == current_user.id),
+        )
     )
     season = result.scalar_one_or_none()
 
@@ -449,7 +478,9 @@ async def list_media_files(
     search: Optional[str] = None,
 ):
     """List media files with pagination and filters."""
-    query = select(MediaFile).options(selectinload(MediaFile.audio_tracks))
+    query = select(MediaFile).options(selectinload(MediaFile.audio_tracks)).where(
+        MediaFile.user_id == current_user.id
+    )
 
     filters = []
     if has_issues is not None:
@@ -459,7 +490,10 @@ async def list_media_files(
         filters.append(
             or_(
                 MediaFile.season_id.in_(
-                    select(Season.id).where(Season.show_id == show_id)
+                    select(Season.id).where(
+                        Season.show_id == show_id,
+                        Season.show.has(Show.user_id == current_user.id),
+                    )
                 ),
                 MediaFile.show_id == show_id,
             )
@@ -499,7 +533,7 @@ async def get_media_file(
     result = await db.execute(
         select(MediaFile)
         .options(selectinload(MediaFile.audio_tracks))
-        .where(MediaFile.id == file_id)
+        .where(MediaFile.id == file_id, MediaFile.user_id == current_user.id)
     )
     mf = result.scalar_one_or_none()
 

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -94,7 +94,11 @@ async def list_scan_locations(
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
     """List all configured scan locations."""
-    result = await db.execute(select(ScanLocation).order_by(ScanLocation.label))
+    result = await db.execute(
+        select(ScanLocation)
+        .where(ScanLocation.user_id == current_user.id)
+        .order_by(ScanLocation.label)
+    )
     locations = result.scalars().all()
     return locations
 
@@ -108,7 +112,10 @@ async def create_scan_location(
     """Add a new scan location."""
     # Check if path already exists
     result = await db.execute(
-        select(ScanLocation).where(ScanLocation.path == location.path)
+        select(ScanLocation).where(
+            ScanLocation.path == location.path,
+            ScanLocation.user_id == current_user.id,
+        )
     )
     existing = result.scalar_one_or_none()
 
@@ -119,6 +126,7 @@ async def create_scan_location(
         )
 
     new_location = ScanLocation(
+        user_id=current_user.id,
         path=location.path,
         label=location.label,
         media_type=location.media_type,
@@ -139,7 +147,10 @@ async def get_scan_location(
 ):
     """Get a specific scan location."""
     result = await db.execute(
-        select(ScanLocation).where(ScanLocation.id == location_id)
+        select(ScanLocation).where(
+            ScanLocation.id == location_id,
+            ScanLocation.user_id == current_user.id,
+        )
     )
     location = result.scalar_one_or_none()
 
@@ -161,7 +172,10 @@ async def update_scan_location(
 ):
     """Update a scan location."""
     result = await db.execute(
-        select(ScanLocation).where(ScanLocation.id == location_id)
+        select(ScanLocation).where(
+            ScanLocation.id == location_id,
+            ScanLocation.user_id == current_user.id,
+        )
     )
     location = result.scalar_one_or_none()
 
@@ -192,7 +206,10 @@ async def delete_scan_location(
 ):
     """Delete a scan location."""
     result = await db.execute(
-        select(ScanLocation).where(ScanLocation.id == location_id)
+        select(ScanLocation).where(
+            ScanLocation.id == location_id,
+            ScanLocation.user_id == current_user.id,
+        )
     )
     location = result.scalar_one_or_none()
 
@@ -202,7 +219,12 @@ async def delete_scan_location(
             detail="Scan location not found",
         )
 
-    await db.execute(delete(ScanLocation).where(ScanLocation.id == location_id))
+    await db.execute(
+        delete(ScanLocation).where(
+            ScanLocation.id == location_id,
+            ScanLocation.user_id == current_user.id,
+        )
+    )
 
 
 # ============== Scan Operations ==============
@@ -239,11 +261,15 @@ async def start_scan(
                 select(ScanLocation).where(
                     ScanLocation.id.in_(request.location_ids),
                     ScanLocation.enabled == True,
+                    ScanLocation.user_id == current_user.id,
                 )
             )
         else:
             result = await db.execute(
-                select(ScanLocation).where(ScanLocation.enabled == True)
+                select(ScanLocation).where(
+                    ScanLocation.enabled == True,
+                    ScanLocation.user_id == current_user.id,
+                )
             )
 
         locations = result.scalars().all()
@@ -266,6 +292,7 @@ async def start_scan(
         locations=[loc.path for loc in locations],
         location_media_types={loc.path: loc.media_type for loc in locations},
         incremental=request.incremental,
+        user_id=current_user.id,
         user_plex_token=current_user.plex_token,
     )
 

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -50,6 +50,8 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 async def init_db() -> None:
     """Initialize database tables."""
     from app.models.entities import Base
+    from app.models.migrations import apply_ownership_migrations
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        await apply_ownership_migrations(conn)

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -40,6 +40,15 @@ class User(Base):
     preferences: Mapped[list["UserPreference"]] = relationship(
         "UserPreference", back_populates="user", cascade="all, delete-orphan"
     )
+    shows: Mapped[list["Show"]] = relationship(
+        "Show", back_populates="user", cascade="all, delete-orphan"
+    )
+    media_files: Mapped[list["MediaFile"]] = relationship(
+        "MediaFile", back_populates="user", cascade="all, delete-orphan"
+    )
+    scan_locations: Mapped[list["ScanLocation"]] = relationship(
+        "ScanLocation", back_populates="user", cascade="all, delete-orphan"
+    )
 
 
 class UserPreference(Base):
@@ -64,6 +73,9 @@ class Show(Base):
     __tablename__ = "shows"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
     title: Mapped[str] = mapped_column(String(512), nullable=False)
     media_type: Mapped[str] = mapped_column(
         String(20), default="tv", nullable=False
@@ -83,6 +95,7 @@ class Show(Base):
     )
 
     # Relationships
+    user: Mapped["User"] = relationship("User", back_populates="shows")
     seasons: Mapped[list["Season"]] = relationship(
         "Season", back_populates="show", cascade="all, delete-orphan"
     )
@@ -120,6 +133,9 @@ class MediaFile(Base):
     __tablename__ = "media_files"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
     show_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("shows.id", ondelete="SET NULL"), nullable=True
     )
@@ -141,6 +157,7 @@ class MediaFile(Base):
     issue_details: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     # Relationships
+    user: Mapped["User"] = relationship("User", back_populates="media_files")
     show: Mapped[Optional["Show"]] = relationship(
         "Show", back_populates="media_files", foreign_keys=[show_id]
     )
@@ -188,7 +205,10 @@ class ScanLocation(Base):
     __tablename__ = "scan_locations"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    path: Mapped[str] = mapped_column(String(1024), unique=True, nullable=False)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    path: Mapped[str] = mapped_column(String(1024), nullable=False)
     label: Mapped[str] = mapped_column(String(255), nullable=False)
     media_type: Mapped[str] = mapped_column(
         String(20), default="tv", nullable=False
@@ -199,3 +219,6 @@ class ScanLocation(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=_utcnow, nullable=False
     )
+
+    # Relationships
+    user: Mapped["User"] = relationship("User", back_populates="scan_locations")

--- a/backend/app/models/migrations.py
+++ b/backend/app/models/migrations.py
@@ -1,0 +1,71 @@
+"""Lightweight schema migrations for backward compatibility."""
+
+from __future__ import annotations
+
+from sqlalchemy import inspect, text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+
+async def _ensure_bootstrap_user(conn: AsyncConnection) -> int:
+    """Return an owner user id, creating a bootstrap owner when necessary."""
+    owner_id = await conn.scalar(text("SELECT MIN(id) FROM users"))
+    if owner_id is not None:
+        return int(owner_id)
+
+    result = await conn.execute(
+        text(
+            """
+            INSERT INTO users (plex_user_id, plex_username, plex_email, plex_token, plex_thumb_url, created_at, last_login)
+            VALUES ('bootstrap-owner', 'bootstrap-owner', NULL, 'bootstrap-owner-token', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            """
+        )
+    )
+
+    inserted_id = result.lastrowid
+    if inserted_id is not None:
+        return int(inserted_id)
+
+    owner_id = await conn.scalar(
+        text("SELECT id FROM users WHERE plex_user_id = 'bootstrap-owner' LIMIT 1")
+    )
+    return int(owner_id)
+
+
+async def apply_ownership_migrations(conn: AsyncConnection) -> None:
+    """Add per-user ownership columns and backfill old rows."""
+    inspector = inspect(conn.sync_connection)
+
+    for table_name in ("shows", "media_files", "scan_locations"):
+        columns = {c["name"] for c in inspector.get_columns(table_name)}
+        if "user_id" not in columns:
+            await conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN user_id INTEGER"))
+
+    owner_id = await _ensure_bootstrap_user(conn)
+
+    await conn.execute(
+        text("UPDATE shows SET user_id = :owner_id WHERE user_id IS NULL"),
+        {"owner_id": owner_id},
+    )
+    await conn.execute(
+        text("UPDATE media_files SET user_id = :owner_id WHERE user_id IS NULL"),
+        {"owner_id": owner_id},
+    )
+    await conn.execute(
+        text("UPDATE scan_locations SET user_id = :owner_id WHERE user_id IS NULL"),
+        {"owner_id": owner_id},
+    )
+
+    await conn.execute(
+        text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_scan_locations_user_path ON scan_locations (user_id, path)"
+        )
+    )
+    await conn.execute(
+        text("CREATE INDEX IF NOT EXISTS ix_shows_user_id ON shows (user_id)")
+    )
+    await conn.execute(
+        text("CREATE INDEX IF NOT EXISTS ix_media_files_user_id ON media_files (user_id)")
+    )
+    await conn.execute(
+        text("CREATE INDEX IF NOT EXISTS ix_scan_locations_user_id ON scan_locations (user_id)")
+    )

--- a/backend/migrations/20260207_add_user_ownership.sql
+++ b/backend/migrations/20260207_add_user_ownership.sql
@@ -1,0 +1,16 @@
+-- Adds per-user ownership for root entities.
+-- Backfill strategy:
+-- 1) Use the oldest existing user as owner for legacy rows.
+-- 2) If no users exist, create a bootstrap-owner user and assign legacy rows to it.
+
+ALTER TABLE shows ADD COLUMN IF NOT EXISTS user_id INTEGER;
+ALTER TABLE media_files ADD COLUMN IF NOT EXISTS user_id INTEGER;
+ALTER TABLE scan_locations ADD COLUMN IF NOT EXISTS user_id INTEGER;
+
+-- The runtime migration helper in app.models.migrations performs safe backfill and indexing
+-- across SQLite/PostgreSQL, including bootstrap owner creation when needed.
+
+CREATE INDEX IF NOT EXISTS ix_shows_user_id ON shows (user_id);
+CREATE INDEX IF NOT EXISTS ix_media_files_user_id ON media_files (user_id);
+CREATE INDEX IF NOT EXISTS ix_scan_locations_user_id ON scan_locations (user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_scan_locations_user_path ON scan_locations (user_id, path);

--- a/backend/tests/test_user_isolation.py
+++ b/backend/tests/test_user_isolation.py
@@ -1,0 +1,106 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+
+from app.api.auth import get_current_user
+from app.api.media import router as media_router
+from app.api.scan import router as scan_router
+from app.models.database import get_db
+from app.models.entities import Base, User, Show, ScanLocation
+
+
+@pytest.fixture
+async def test_app():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_maker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    app = FastAPI()
+    app.include_router(scan_router, prefix="/api/scan")
+    app.include_router(media_router, prefix="/api/media")
+
+    users = {}
+
+    async def override_db():
+        async with session_maker() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    async with session_maker() as session:
+        user_a = User(plex_user_id="1", plex_username="user-a", plex_token="token-a")
+        user_b = User(plex_user_id="2", plex_username="user-b", plex_token="token-b")
+        session.add_all([user_a, user_b])
+        await session.flush()
+
+        show_b = Show(user_id=user_b.id, title="Other User Show", media_type="tv", is_anime=False)
+        session.add(show_b)
+        scan_b = ScanLocation(user_id=user_b.id, path="/media/user-b", label="B", media_type="tv", enabled=True)
+        session.add(scan_b)
+        await session.commit()
+
+        users["a"] = user_a
+        users["b"] = user_b
+        users["show_b_id"] = show_b.id
+        users["scan_b_id"] = scan_b.id
+
+    app.dependency_overrides[get_db] = override_db
+
+    yield app, users
+
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_user_cannot_view_or_edit_other_users_show(test_app):
+    app, users = test_app
+
+    async def override_current_user():
+        return users["a"]
+
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        get_resp = await client.get(f"/api/media/shows/{users['show_b_id']}")
+        assert get_resp.status_code == 404
+
+        patch_resp = await client.patch(
+            f"/api/media/shows/{users['show_b_id']}",
+            json={"media_type": "anime"},
+        )
+        assert patch_resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_user_cannot_access_other_users_scan_locations(test_app):
+    app, users = test_app
+
+    async def override_current_user():
+        return users["a"]
+
+    app.dependency_overrides[get_current_user] = override_current_user
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        list_resp = await client.get("/api/scan/locations")
+        assert list_resp.status_code == 200
+        assert all(loc["id"] != users["scan_b_id"] for loc in list_resp.json())
+
+        get_resp = await client.get(f"/api/scan/locations/{users['scan_b_id']}")
+        assert get_resp.status_code == 404
+
+        patch_resp = await client.patch(
+            f"/api/scan/locations/{users['scan_b_id']}",
+            json={"label": "hijack"},
+        )
+        assert patch_resp.status_code == 404
+
+        delete_resp = await client.delete(f"/api/scan/locations/{users['scan_b_id']}")
+        assert delete_resp.status_code == 404


### PR DESCRIPTION
### Motivation
- Ensure users only see and manage their own data by adding per-user ownership to root entities and scoping all reads/writes to the authenticated user.
- Make the scanner write-path and scan-location stats updates operate in the initiating user's context so background scans cannot cross user boundaries.
- Provide a safe migration/backfill path for existing installations so legacy rows are assigned to an owner and per-user constraints/indexes are added.

### Description
- Add `user_id` foreign keys and relationships on `User` for `Show`, `MediaFile`, and `ScanLocation`, and wire `user` backrefs on those models (see `backend/app/models/entities.py`).
- Scope scanner operations by adding a `user_id` argument to `run_scan`/`process_file`, and ensure show lookup/creation, media dedupe, and scan-location stats are user-scoped (see `backend/app/core/scanner.py`).
- Apply `where(... user_id == current_user.id)` filters to all media and scan read/update/delete queries so endpoints only operate on the current user's rows (see `backend/app/api/media.py` and `backend/app/api/scan.py`).
- Add a runtime migration helper in `backend/app/models/migrations.py` and a SQL migration artifact `backend/migrations/20260207_add_user_ownership.sql` that add `user_id` columns if missing, backfill legacy rows to the oldest user (or create a `bootstrap-owner`), and create ownership indexes.
- Add API tests `backend/tests/test_user_isolation.py` verifying that user A cannot view/edit user B shows and cannot list/get/patch/delete user B scan locations.

### Testing
- Ran the isolation tests with `PYTHONPATH=backend pytest backend/tests/test_user_isolation.py` and they passed (`2 passed`).
- Verified module compilation with `PYTHONPATH=backend python -m compileall backend/app backend/tests` and compilation succeeded.
- Basic static checks: project files updated and imports adjusted to ensure the new `user_id` flows through scanner and APIs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c5ac1970832f88b602a4e17a51b2)