### PR TITLE
docs: add merge-conflict prevention workflow to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,28 @@ DATABASE_URL=postgresql+asyncpg://user:password@host:5432/dbname
 
 When running, visit `/docs` for interactive API documentation (Swagger UI).
 
+## Contributing Without Merge Conflicts
+
+If your pull request frequently shows conflicts, keep your branch synced before you push:
+
+```bash
+# From your feature branch
+git fetch origin
+git rebase origin/main
+
+# Resolve any conflicts, then continue
+git add <resolved-files>
+git rebase --continue
+
+# Update your remote branch after rebase
+git push --force-with-lease
+```
+
+Tips:
+- Make smaller PRs to reduce overlap with other changes.
+- Rebase right before opening a PR (and again before merge if the branch gets stale).
+- Avoid committing generated files unless they are required by the project.
+
 ## License
 
 MIT


### PR DESCRIPTION
### Motivation

- Developers encountering frequent PR merge conflicts need a simple, documented workflow to keep branches in sync and reduce conflict frequency.

### Description

- Updated `README.md` to add a new `Contributing Without Merge Conflicts` section with a concrete `git fetch` / `git rebase` / `git push --force-with-lease` workflow example.
- Included short tips recommending smaller PRs, rebasing before opening/merging, and avoiding committing generated files.
- This change is documentation-only and modifies only `README.md`.

### Testing

- Verified repository state with `git status --short --branch` which completed successfully.
- Scanned for unresolved merge markers with `rg -n "^(<<<<<<<|=======|>>>>>>>)" .` and found none.
- Confirmed the new README content with `nl -ba README.md | sed -n '110,190p'` which showed the added section.
- Staged the README change with `git add README.md` and executed the PR creation flow via the repository tooling which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69880914db18832fa996134e5147200f)