### PR TITLE
Enforce per-user uniqueness for scan locations and add isolation tests

### DIFF
--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -126,9 +126,12 @@ async def create_scan_location(
         raise _invalid_scan_input(str(exc)) from exc
     media_type = _validate_scan_media_type(location.media_type)
 
-    # Check if path already exists
+    # Check if path already exists for the current user
     result = await db.execute(
-        select(ScanLocation).where(ScanLocation.path == normalized_path)
+        select(ScanLocation).where(
+            ScanLocation.user_id == current_user.id,
+            ScanLocation.path == normalized_path,
+        )
     )
     existing = result.scalar_one_or_none()
 
@@ -139,6 +142,7 @@ async def create_scan_location(
         )
 
     new_location = ScanLocation(
+        user_id=current_user.id,
         path=normalized_path,
         label=location.label,
         media_type=media_type,


### PR DESCRIPTION
### Motivation
- Prevent global path collision by ensuring scan locations are unique per user so different users can add the same path independently.
- Ensure newly created `ScanLocation` rows are explicitly owned by the authenticated user.

### Description
- Modified `create_scan_location` to scope duplicate checks to `ScanLocation.user_id == current_user.id` in addition to `ScanLocation.path` so duplicates are per-user (`backend/app/api/scan.py`).
- Set `user_id=current_user.id` when constructing the new `ScanLocation` so ownership is persisted (`backend/app/api/scan.py`).
- Kept path normalization via `validate_media_root_path` before duplicate checks and persistence to ensure consistent comparisons (`backend/app/api/scan.py`).
- Added API tests to `backend/tests/test_user_isolation.py` to verify that the same path is allowed for different users, rejected for the same user, and that created locations are only accessible by their owner.

### Testing
- Ran `pytest -q backend/tests/test_user_isolation.py backend/tests/test_scan_validation.py` and all tests passed: `7 passed, 1 warning`.
- The added tests cover per-user duplicate behavior and ownership/isolation of created scan locations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69880c4bec88832f864140b391e915c8)