### PR TITLE
Pass user_id into scanner.process_file and add single-file happy-path test

### DIFF
--- a/backend/app/core/scanner.py
+++ b/backend/app/core/scanner.py
@@ -365,7 +365,7 @@ async def run_scan(
                     current_file=os.path.basename(file_path),
                 )
 
-                await scanner.process_file(file_path, base_path, media_type, db)
+                await scanner.process_file(file_path, base_path, media_type, user_id, db)
 
                 # Commit periodically
                 if (i + 1) % 50 == 0:

--- a/backend/tests/test_scanner_run_scan.py
+++ b/backend/tests/test_scanner_run_scan.py
@@ -1,0 +1,66 @@
+"""Tests for scanner run loop argument passing and happy-path status."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from app.core.scan_state import scan_state_manager
+from app.core.scanner import run_scan
+
+
+class _FakeResult:
+    def scalar_one_or_none(self):
+        return None
+
+
+class _FakeSession:
+    async def execute(self, *args, **kwargs):
+        return _FakeResult()
+
+    async def scalar(self, *args, **kwargs):
+        return 0
+
+    async def commit(self):
+        return None
+
+
+class _FakeSessionContext:
+    async def __aenter__(self):
+        return _FakeSession()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class RunScanArgumentPassingTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        await scan_state_manager.reset()
+
+    async def asyncTearDown(self) -> None:
+        await scan_state_manager.reset()
+
+    async def test_run_scan_single_file_calls_process_file_with_user_id_and_no_errors(self):
+        file_path = "/media/tv/Show/Season 01/E01.mkv"
+
+        with (
+            patch("app.core.scanner.MediaScanner.discover_files", return_value=[file_path]),
+            patch("app.core.scanner.MediaScanner.process_file", new_callable=AsyncMock) as process_file,
+            patch("app.core.scanner.async_session_maker", return_value=_FakeSessionContext()),
+        ):
+            await run_scan(
+                locations=["/media/tv"],
+                location_media_types={"/media/tv": "tv"},
+                user_id=42,
+                incremental=False,
+            )
+
+        process_file.assert_awaited_once()
+        process_file.assert_awaited_once_with(file_path, "/media/tv", "tv", 42, unittest.mock.ANY)
+
+        status = await scan_state_manager.get_status()
+        self.assertEqual(status.files_total, 1)
+        self.assertEqual(status.files_scanned, 1)
+        self.assertEqual(status.errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- The `run_scan` loop called `MediaScanner.process_file` with the wrong argument order/number and needed to pass `user_id` to match the method signature and ensure DB operations use the correct user context.\

### Description
- Updated `run_scan` in `backend/app/core/scanner.py` to call `await scanner.process_file(file_path, base_path, media_type, user_id, db)` so it matches `process_file(file_path, base_path, media_type, user_id, db)`.\
- Added `backend/tests/test_scanner_run_scan.py` which patches `MediaScanner.discover_files`, uses an `AsyncMock` for `MediaScanner.process_file`, and stubs `async_session_maker` to exercise a single-file scan path.\
- The new test asserts `process_file` is awaited once with the exact arguments including `user_id` and that `scan_state_manager` reports one total/one scanned file and an empty `errors` list for the happy path.\

### Testing
- Ran `pytest -q backend/tests/test_scanner_run_scan.py backend/tests/test_scan_state.py` and all tests passed, with output `5 passed` and one unrelated warning about default `SECRET_KEY`.\
- The added test `test_run_scan_single_file_calls_process_file_with_user_id_and_no_errors` verifies argument passing and happy-path scan status metrics successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69880dc82048832f96a1839e0a9e9ef7)