### PR TITLE
Isolate scan state by user across API and scanner

### DIFF
--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -79,9 +79,7 @@ async def browse_directories(
     try:
         for entry in sorted(resolved.iterdir()):
             if entry.is_dir() and not entry.name.startswith("."):
-                directories.append(
-                    DirectoryEntry(name=entry.name, path=str(entry))
-                )
+                directories.append(DirectoryEntry(name=entry.name, path=str(entry)))
     except PermissionError:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -112,7 +110,11 @@ async def list_scan_locations(
     return locations
 
 
-@router.post("/locations", response_model=ScanLocationResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/locations",
+    response_model=ScanLocationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_scan_location(
     location: ScanLocationCreate,
     current_user: Annotated[User, Depends(get_current_user)],
@@ -251,7 +253,7 @@ async def get_scan_status(
     current_user: Annotated[User, Depends(get_current_user)],
 ):
     """Get current scan status."""
-    return await scan_state_manager.get_status()
+    return await scan_state_manager.get_status(current_user.id)
 
 
 @router.post("/start", response_model=ScanStatus)
@@ -295,7 +297,7 @@ async def start_scan(
             detail="No enabled scan locations found",
         )
 
-    started_status = await scan_state_manager.start_scan()
+    started_status = await scan_state_manager.start_scan(current_user.id)
     if started_status is None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -323,7 +325,7 @@ async def cancel_scan(
     current_user: Annotated[User, Depends(get_current_user)],
 ):
     """Cancel the current scan."""
-    cancelled_status = await scan_state_manager.cancel_scan()
+    cancelled_status = await scan_state_manager.cancel_scan(current_user.id)
     if cancelled_status is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/core/scan_state.py
+++ b/backend/app/core/scan_state.py
@@ -11,22 +11,28 @@ class ScanStateManager:
 
     def __init__(self) -> None:
         self._lock = asyncio.Lock()
-        self._status = ScanStatus(is_running=False)
-        self._cancel_requested = False
+        self._status_by_user: dict[int, ScanStatus] = {}
+        self._cancel_requested_by_user: dict[int, bool] = {}
 
-    async def get_status(self) -> ScanStatus:
+    def _get_or_create_status(self, user_id: int) -> ScanStatus:
+        if user_id not in self._status_by_user:
+            self._status_by_user[user_id] = ScanStatus(is_running=False)
+        return self._status_by_user[user_id]
+
+    async def get_status(self, user_id: int) -> ScanStatus:
         """Return a safe copy of the current scan status."""
         async with self._lock:
-            return self._status.model_copy(deep=True)
+            return self._get_or_create_status(user_id).model_copy(deep=True)
 
-    async def start_scan(self) -> ScanStatus | None:
+    async def start_scan(self, user_id: int) -> ScanStatus | None:
         """Transition to running state, returning None if already running."""
         async with self._lock:
-            if self._status.is_running:
+            status = self._get_or_create_status(user_id)
+            if status.is_running:
                 return None
 
-            self._cancel_requested = False
-            self._status = ScanStatus(
+            self._cancel_requested_by_user[user_id] = False
+            self._status_by_user[user_id] = ScanStatus(
                 is_running=True,
                 current_location=None,
                 files_scanned=0,
@@ -35,49 +41,53 @@ class ScanStateManager:
                 started_at=datetime.now(timezone.utc),
                 errors=[],
             )
-            return self._status.model_copy(deep=True)
+            return self._status_by_user[user_id].model_copy(deep=True)
 
-    async def cancel_scan(self) -> ScanStatus | None:
+    async def cancel_scan(self, user_id: int) -> ScanStatus | None:
         """Request cancellation for a running scan."""
         async with self._lock:
-            if not self._status.is_running:
+            status = self._get_or_create_status(user_id)
+            if not status.is_running:
                 return None
-            self._cancel_requested = True
-            return self._status.model_copy(deep=True)
+            self._cancel_requested_by_user[user_id] = True
+            return status.model_copy(deep=True)
 
-    async def is_cancel_requested(self) -> bool:
+    async def is_cancel_requested(self, user_id: int) -> bool:
         """Check whether cancellation has been requested."""
         async with self._lock:
-            return self._cancel_requested
+            return self._cancel_requested_by_user.get(user_id, False)
 
-    async def update_status(self, **kwargs) -> ScanStatus:
+    async def update_status(self, user_id: int, **kwargs) -> ScanStatus:
         """Update scan status fields and return a copy of the new state."""
         async with self._lock:
-            current = self._status.model_dump()
+            status = self._get_or_create_status(user_id)
+            current = status.model_dump()
             current.update(kwargs)
-            self._status = ScanStatus(**current)
-            return self._status.model_copy(deep=True)
+            self._status_by_user[user_id] = ScanStatus(**current)
+            return self._status_by_user[user_id].model_copy(deep=True)
 
-    async def append_error(self, error: str) -> ScanStatus:
+    async def append_error(self, user_id: int, error: str) -> ScanStatus:
         """Append an error message to scan status."""
         async with self._lock:
-            self._status.errors.append(error)
-            return self._status.model_copy(deep=True)
+            status = self._get_or_create_status(user_id)
+            status.errors.append(error)
+            return status.model_copy(deep=True)
 
-    async def finish_scan(self) -> ScanStatus:
+    async def finish_scan(self, user_id: int) -> ScanStatus:
         """Transition to not running while keeping progress context."""
         async with self._lock:
-            self._cancel_requested = False
-            self._status.is_running = False
-            self._status.current_location = None
-            self._status.current_file = None
-            return self._status.model_copy(deep=True)
+            status = self._get_or_create_status(user_id)
+            self._cancel_requested_by_user[user_id] = False
+            status.is_running = False
+            status.current_location = None
+            status.current_file = None
+            return status.model_copy(deep=True)
 
     async def reset(self) -> None:
         """Reset state for tests."""
         async with self._lock:
-            self._cancel_requested = False
-            self._status = ScanStatus(is_running=False)
+            self._cancel_requested_by_user = {}
+            self._status_by_user = {}
 
 
 scan_state_manager = ScanStateManager()

--- a/backend/tests/test_scan_state.py
+++ b/backend/tests/test_scan_state.py
@@ -10,44 +10,56 @@ class ScanStateManagerTests(unittest.IsolatedAsyncioTestCase):
         self.manager = ScanStateManager()
 
     async def test_start_scan_transitions_to_running(self) -> None:
-        started = await self.manager.start_scan()
+        started = await self.manager.start_scan(user_id=1)
 
         self.assertIsNotNone(started)
         self.assertTrue(started.is_running)
         self.assertEqual(started.files_scanned, 0)
         self.assertEqual(started.files_total, 0)
-        self.assertFalse(await self.manager.is_cancel_requested())
+        self.assertFalse(await self.manager.is_cancel_requested(user_id=1))
 
     async def test_duplicate_start_is_rejected(self) -> None:
-        first = await self.manager.start_scan()
-        second = await self.manager.start_scan()
+        first = await self.manager.start_scan(user_id=1)
+        second = await self.manager.start_scan(user_id=1)
 
         self.assertIsNotNone(first)
         self.assertIsNone(second)
 
     async def test_cancel_scan_transitions_when_running(self) -> None:
-        await self.manager.start_scan()
+        await self.manager.start_scan(user_id=1)
 
-        status = await self.manager.cancel_scan()
+        status = await self.manager.cancel_scan(user_id=1)
 
         self.assertIsNotNone(status)
         self.assertTrue(status.is_running)
-        self.assertTrue(await self.manager.is_cancel_requested())
+        self.assertTrue(await self.manager.is_cancel_requested(user_id=1))
 
     async def test_status_updates_and_finish_scan(self) -> None:
-        await self.manager.start_scan()
-        await self.manager.update_status(current_location="/media/test", files_total=3, files_scanned=1)
+        await self.manager.start_scan(user_id=1)
+        await self.manager.update_status(
+            user_id=1, current_location="/media/test", files_total=3, files_scanned=1
+        )
 
-        status = await self.manager.get_status()
+        status = await self.manager.get_status(user_id=1)
         self.assertEqual(status.current_location, "/media/test")
         self.assertEqual(status.files_total, 3)
         self.assertEqual(status.files_scanned, 1)
 
-        finished = await self.manager.finish_scan()
+        finished = await self.manager.finish_scan(user_id=1)
         self.assertFalse(finished.is_running)
         self.assertIsNone(finished.current_location)
         self.assertIsNone(finished.current_file)
-        self.assertFalse(await self.manager.is_cancel_requested())
+        self.assertFalse(await self.manager.is_cancel_requested(user_id=1))
+
+    async def test_user_states_are_isolated(self) -> None:
+        await self.manager.start_scan(user_id=1)
+
+        user_two_status = await self.manager.get_status(user_id=2)
+        self.assertFalse(user_two_status.is_running)
+
+        await self.manager.cancel_scan(user_id=1)
+        self.assertTrue(await self.manager.is_cancel_requested(user_id=1))
+        self.assertFalse(await self.manager.is_cancel_requested(user_id=2))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_scanner_run_scan.py
+++ b/backend/tests/test_scanner_run_scan.py
@@ -38,13 +38,22 @@ class RunScanArgumentPassingTests(unittest.IsolatedAsyncioTestCase):
     async def asyncTearDown(self) -> None:
         await scan_state_manager.reset()
 
-    async def test_run_scan_single_file_calls_process_file_with_user_id_and_no_errors(self):
+    async def test_run_scan_single_file_calls_process_file_with_user_id_and_no_errors(
+        self,
+    ):
         file_path = "/media/tv/Show/Season 01/E01.mkv"
 
         with (
-            patch("app.core.scanner.MediaScanner.discover_files", return_value=[file_path]),
-            patch("app.core.scanner.MediaScanner.process_file", new_callable=AsyncMock) as process_file,
-            patch("app.core.scanner.async_session_maker", return_value=_FakeSessionContext()),
+            patch(
+                "app.core.scanner.MediaScanner.discover_files", return_value=[file_path]
+            ),
+            patch(
+                "app.core.scanner.MediaScanner.process_file", new_callable=AsyncMock
+            ) as process_file,
+            patch(
+                "app.core.scanner.async_session_maker",
+                return_value=_FakeSessionContext(),
+            ),
         ):
             await run_scan(
                 locations=["/media/tv"],
@@ -54,9 +63,11 @@ class RunScanArgumentPassingTests(unittest.IsolatedAsyncioTestCase):
             )
 
         process_file.assert_awaited_once()
-        process_file.assert_awaited_once_with(file_path, "/media/tv", "tv", 42, unittest.mock.ANY)
+        process_file.assert_awaited_once_with(
+            file_path, "/media/tv", "tv", 42, unittest.mock.ANY
+        )
 
-        status = await scan_state_manager.get_status()
+        status = await scan_state_manager.get_status(42)
         self.assertEqual(status.files_total, 1)
         self.assertEqual(status.files_scanned, 1)
         self.assertEqual(status.errors, [])


### PR DESCRIPTION
### Motivation
- Prevent cross-user interference by keying scan state and cancellation flags to the owning `user_id` so a user's scan status and cancel request are private to them.
- Make scan control APIs operate in the authenticated user context so callers cannot view or cancel another user’s scan.

### Description
- Reworked `ScanStateManager` to store `_status_by_user` and `_cancel_requested_by_user` and changed methods to accept `user_id` (e.g. `get_status(user_id)`, `start_scan(user_id)`, `cancel_scan(user_id)`).
- Updated API endpoints in `backend/app/api/scan.py` so `/start`, `/status`, and `/cancel` call the scan state manager with `current_user.id`.
- Updated `run_scan` and `MediaScanner` interactions in `backend/app/core/scanner.py` to pass `user_id` into all `scan_state_manager` calls (`update_status`, `append_error`, `is_cancel_requested`, `finish_scan`).
- Updated and added tests in `backend/tests/` to reflect new method signatures and validate multi-user isolation, including a reset fixture for scan state and API-level tests asserting one user cannot read or cancel another user’s scan.

### Testing
- Ran code formatting with `black` on modified files and applied updates successfully.
- Executed `pytest -q backend/tests/test_scan_state.py backend/tests/test_scanner_run_scan.py backend/tests/test_user_isolation.py` and all tests passed (`13 passed`, `1 warning`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69880e94c2b8832fa2f8f00c6c0166de)