### PR TITLE
Encrypt Plex tokens at rest and backfill legacy plaintext values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 
 # Security - REQUIRED, generate with: openssl rand -hex 32
 SECRET_KEY=change-me-in-production-use-openssl-rand-hex-32
+# At-rest token encryption key - generate with: openssl rand -base64 32
+ENCRYPTION_KEY=change-me-trackhound-encryption-key
 
 # CORS - set to the URL you'll access TrackHound from
 # For Unraid, use your server IP: http://192.168.x.x:8383

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
+from app.core.encryption import encrypt_value
 from app.models.database import get_db
 from app.models.entities import User
 from app.models.schemas import PlexPinResponse, TokenResponse, UserResponse
@@ -188,7 +189,7 @@ async def complete_plex_login(
             # Update existing user
             user.plex_username = plex_username
             user.plex_email = plex_email
-            user.plex_token = auth_token
+            user.plex_token = encrypt_value(auth_token)
             user.plex_thumb_url = plex_thumb
             user.last_login = datetime.now(timezone.utc)
         else:
@@ -197,7 +198,7 @@ async def complete_plex_login(
                 plex_user_id=plex_user_id,
                 plex_username=plex_username,
                 plex_email=plex_email,
-                plex_token=auth_token,
+                plex_token=encrypt_value(auth_token),
                 plex_thumb_url=plex_thumb,
             )
             db.add(user)

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -8,6 +8,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import get_current_user
+from app.core.encryption import decrypt_value
 from app.models.database import get_db
 from app.models.entities import ScanLocation, User
 from app.models.schemas import (
@@ -314,7 +315,7 @@ async def start_scan(
         location_media_types={loc.path: loc.media_type for loc in locations},
         incremental=request.incremental,
         user_id=current_user.id,
-        user_plex_token=current_user.plex_token,
+        user_plex_token=decrypt_value(current_user.plex_token),
     )
 
     return started_status

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,6 +10,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 logger = logging.getLogger(__name__)
 
 _INSECURE_DEFAULT_KEY = "change-me-in-production-use-openssl-rand-hex-32"
+_INSECURE_DEFAULT_ENCRYPTION_KEY = "change-me-trackhound-encryption-key"
 
 
 class Settings(BaseSettings):
@@ -37,6 +38,7 @@ class Settings(BaseSettings):
 
     # Security
     secret_key: str = _INSECURE_DEFAULT_KEY
+    encryption_key: str = _INSECURE_DEFAULT_ENCRYPTION_KEY
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 60 * 24 * 7  # 1 week
 
@@ -61,6 +63,18 @@ class Settings(BaseSettings):
             warnings.warn(
                 "Using default SECRET_KEY — set a secure value before deploying. "
                 "Generate one with: openssl rand -hex 32",
+                stacklevel=2,
+            )
+
+        if self.encryption_key == _INSECURE_DEFAULT_ENCRYPTION_KEY:
+            if self.environment == "production":
+                raise ValueError(
+                    "ENCRYPTION_KEY must be set to a secure value in production. "
+                    "Generate one with: openssl rand -base64 32"
+                )
+            warnings.warn(
+                "Using default ENCRYPTION_KEY — set a secure value before deploying. "
+                "Generate one with: openssl rand -base64 32",
                 stacklevel=2,
             )
 

--- a/backend/app/core/encryption.py
+++ b/backend/app/core/encryption.py
@@ -1,0 +1,53 @@
+"""Helpers for encrypting and decrypting sensitive at-rest values."""
+
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from app.config import get_settings
+
+_ENCRYPTED_PREFIX = "enc::"
+
+
+def _derive_key(raw_key: str) -> bytes:
+    """Derive a valid Fernet key from configured encryption key material."""
+    try:
+        decoded = base64.urlsafe_b64decode(raw_key.encode("utf-8"))
+        if len(decoded) == 32:
+            return raw_key.encode("utf-8")
+    except Exception:
+        pass
+
+    digest = hashlib.sha256(raw_key.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest)
+
+
+def _cipher() -> Fernet:
+    settings = get_settings()
+    return Fernet(_derive_key(settings.encryption_key))
+
+
+def is_encrypted(value: str | None) -> bool:
+    """Return true when value is encrypted by TrackHound token encryption."""
+    return bool(value) and value.startswith(_ENCRYPTED_PREFIX)
+
+
+def encrypt_value(value: str) -> str:
+    """Encrypt a plaintext value unless it is already encrypted."""
+    if is_encrypted(value):
+        return value
+    token = _cipher().encrypt(value.encode("utf-8")).decode("utf-8")
+    return f"{_ENCRYPTED_PREFIX}{token}"
+
+
+def decrypt_value(value: str) -> str:
+    """Decrypt a TrackHound encrypted value, returning plaintext for legacy values."""
+    if not is_encrypted(value):
+        return value
+
+    encrypted = value[len(_ENCRYPTED_PREFIX) :]
+    try:
+        return _cipher().decrypt(encrypted.encode("utf-8")).decode("utf-8")
+    except InvalidToken as exc:
+        raise ValueError("Unable to decrypt stored value with current ENCRYPTION_KEY") from exc

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -50,8 +50,12 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 async def init_db() -> None:
     """Initialize database tables."""
     from app.models.entities import Base
-    from app.models.migrations import apply_ownership_migrations
+    from app.models.migrations import (
+        apply_ownership_migrations,
+        apply_token_encryption_migration,
+    )
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
         await apply_ownership_migrations(conn)
+        await apply_token_encryption_migration(conn)

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -27,7 +27,7 @@ class User(Base):
     plex_user_id: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     plex_username: Mapped[str] = mapped_column(String(255), nullable=False)
     plex_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    plex_token: Mapped[str] = mapped_column(Text, nullable=False)  # Stored as plaintext — consider encrypting
+    plex_token: Mapped[str] = mapped_column(Text, nullable=False)
     plex_thumb_url: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=_utcnow, nullable=False

--- a/backend/tests/test_token_encryption.py
+++ b/backend/tests/test_token_encryption.py
@@ -1,0 +1,89 @@
+import pytest
+from fastapi import BackgroundTasks
+from sqlalchemy import text, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.api.scan import start_scan
+from app.core.encryption import decrypt_value, encrypt_value, is_encrypted
+from app.core.scan_state import scan_state_manager
+from app.models.entities import Base, ScanLocation, User
+from app.models.migrations import apply_token_encryption_migration
+from app.models.schemas import ScanStartRequest
+
+
+@pytest.mark.anyio
+async def test_token_backfill_encrypts_legacy_plaintext_rows():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(
+            text(
+                """
+                INSERT INTO users (plex_user_id, plex_username, plex_email, plex_token, plex_thumb_url, created_at, last_login)
+                VALUES
+                    ('legacy', 'legacy-user', NULL, 'plaintext-token', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                    ('already', 'encrypted-user', NULL, :encrypted_token, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """
+            ),
+            {"encrypted_token": encrypt_value("already-secret")},
+        )
+
+        await apply_token_encryption_migration(conn)
+
+        rows = (await conn.execute(text("SELECT plex_user_id, plex_token FROM users"))).fetchall()
+
+    row_map = {row[0]: row[1] for row in rows}
+    assert is_encrypted(row_map["legacy"])
+    assert decrypt_value(row_map["legacy"]) == "plaintext-token"
+    assert decrypt_value(row_map["already"]) == "already-secret"
+
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_scan_runtime_receives_decrypted_token_when_db_value_is_encrypted():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_maker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with session_maker() as session:
+        user = User(
+            plex_user_id="1",
+            plex_username="scanner-user",
+            plex_token=encrypt_value("runtime-plaintext-token"),
+        )
+        session.add(user)
+        await session.flush()
+
+        session.add(
+            ScanLocation(
+                user_id=user.id,
+                path="/media/library",
+                label="Library",
+                media_type="tv",
+                enabled=True,
+            )
+        )
+        await session.commit()
+
+    await scan_state_manager.reset()
+    async with session_maker() as session:
+        user = (await session.execute(select(User).where(User.plex_user_id == "1"))).scalar_one()
+        bg = BackgroundTasks()
+
+        response = await start_scan(
+            request=ScanStartRequest(incremental=True),
+            background_tasks=bg,
+            current_user=user,
+            db=session,
+        )
+
+        assert response.is_running is True
+        assert len(bg.tasks) == 1
+        assert bg.tasks[0].kwargs["user_plex_token"] == "runtime-plaintext-token"
+
+    await scan_state_manager.reset()
+    await engine.dispose()


### PR DESCRIPTION
### Motivation

- Protect the sensitive `User.plex_token` by encrypting it at rest with a dedicated application key separate from the JWT `SECRET_KEY`.
- Ensure runtime paths that need plaintext (auth flows, scanner/Plex connector) still receive a decrypted token only when required.
- Safely backfill existing plaintext DB rows so deploying this change does not break existing installations.

### Description

- Added a new `ENCRYPTION_KEY` application setting and validation in `Settings` and documented it in `.env.example` (`ENCRYPTION_KEY`).
- Implemented `app.core.encryption` providing `encrypt_value`, `decrypt_value`, `is_encrypted`, and Fernet-compatible key derivation with an `enc::` storage prefix.
- Persist `plex_token` encrypted in the Plex OAuth callback by applying `encrypt_value` before insert/update, and decrypt at runtime when starting scans by calling `decrypt_value` where the plaintext token is required.
- Added an idempotent migration `apply_token_encryption_migration` and made the bootstrap user token use encrypted storage, and wired the migration into DB initialization (`init_db`).
- Added tests `backend/tests/test_token_encryption.py` that assert legacy plaintext tokens are backfilled to encrypted values and that the scanner runtime receives a decrypted token even when the DB stores an encrypted value.

### Testing

- Ran focused tests with `cd backend && pytest -q tests/test_token_encryption.py tests/test_user_isolation.py tests/test_scanner_run_scan.py`, which passed (10 tests; warnings about default keys only).
- Running the full backend suite with `cd backend && pytest -q` produced unrelated pre-existing failures in `test_media_stats.py` and `test_scan_path_validation.py` (test run summary: 7 failed, 18 passed, 2 warnings) and did not indicate regressions in the token-encryption logic.
- Tests exercise both the migration/backfill logic and runtime decryption path and confirm the DB stores encrypted tokens while runtime usage succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698810205aa4832f9dde046fb489c3cb)