### PR TITLE
Harden deployment defaults for initial Unraid rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cp .env.example .env
 # Build and run with Docker Compose
 docker-compose up -d
 
-# Access at http://localhost:8080
+# Access at http://localhost:8383
 ```
 
 ### Development Setup
@@ -113,7 +113,7 @@ DATABASE_URL=postgresql+asyncpg://user:password@host:5432/dbname
      - /mnt/user/Media/TV:/media/tv:ro
      - /mnt/user/Media/Anime:/media/anime:ro
    ```
-3. Set a secure `SECRET_KEY`
+3. Set secure `SECRET_KEY` and `ENCRYPTION_KEY` values
 4. Access via `http://your-server:8080`
 
 ## API Documentation

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -32,9 +32,9 @@ class Settings(BaseSettings):
     port: int = 8000
 
     # Database - supports both SQLite and PostgreSQL
-    # SQLite: sqlite+aiosqlite:///./data/cineaudit.db
+    # SQLite: sqlite+aiosqlite:///./data/trackhound.db
     # PostgreSQL: postgresql+asyncpg://user:pass@host:5432/dbname
-    database_url: str = "sqlite+aiosqlite:///./data/cineaudit.db"
+    database_url: str = "sqlite+aiosqlite:///./data/trackhound.db"
 
     # Security
     secret_key: str = _INSECURE_DEFAULT_KEY

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -12,8 +12,10 @@ services:
       - /mnt/user/Media/Anime:/media/anime:ro
     environment:
       - SECRET_KEY=${SECRET_KEY:?SECRET_KEY must be set — generate with: openssl rand -hex 32}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set — generate with: openssl rand -base64 32}
       - DATABASE_URL=postgresql+asyncpg://trackhound:${POSTGRES_PASSWORD:-trackhound}@db:5432/trackhound
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:8080}
+      - ENVIRONMENT=production
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       # - /mnt/remotes/yggdrasil/media/TV Shows:/media/yggdrasil/tv:ro
     environment:
       - SECRET_KEY=${SECRET_KEY:?Set SECRET_KEY in .env}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env}
       - DATABASE_URL=sqlite+aiosqlite:///./data/trackhound.db
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:8383}
       - ENVIRONMENT=production


### PR DESCRIPTION
### Motivation
- Ensure first-time Unraid deployments fail fast if encryption keys are not set so insecure defaults are not used. 
- Make production validation consistent between the SQLite and PostgreSQL compose variants by explicitly setting the environment. 
- Align docs and backend defaults with the intended project naming and compose port to avoid confusion during install.

### Description
- Require `ENCRYPTION_KEY` in `docker-compose.yml` so the SQLite container will not start with an insecure default. 
- Require `ENCRYPTION_KEY` and set `ENVIRONMENT=production` in `docker-compose.postgres.yml` to enforce production validation behavior. 
- Update `README.md` to use the actual compose port (`8383`) and to instruct users to set both `SECRET_KEY` and `ENCRYPTION_KEY`. 
- Fix backend default SQLite path in `backend/app/config.py` from `cineaudit.db` to `trackhound.db` to match project naming and docs.

### Testing
- Ran `python -m pytest backend/tests -q` which passed (`25 passed`) with two non-blocking warnings. 
- Ran `npm run build` in `frontend/` which completed successfully and produced a production build. 
- Attempted `docker compose -f docker-compose.yml config` but the `docker` CLI is not available in this environment so compose syntax could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d06f84434832f8229e216a467228d)