### PR TITLE
Add settings toggle and manual default-audio update controls

### DIFF
--- a/backend/app/core/audio_fixer.py
+++ b/backend/app/core/audio_fixer.py
@@ -1,0 +1,54 @@
+"""Utilities for updating media audio default track flags."""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+
+def find_track_index_for_language(audio_tracks: list[dict], language: str) -> int | None:
+    """Find the first audio track index matching the requested language."""
+    normalized = (language or "").lower().strip()
+    for track in audio_tracks:
+        track_language = (track.get("language") or "").lower()
+        track_index = track.get("index")
+        if track_language == normalized and isinstance(track_index, int):
+            return track_index
+    return None
+
+
+def set_default_track_by_index(file_path: str, audio_tracks: list[dict], track_index: int) -> bool:
+    """Set the provided audio track index as default for an MKV file."""
+    if Path(file_path).suffix.lower() != ".mkv":
+        return False
+
+    if shutil.which("mkvpropedit") is None:
+        return False
+
+    valid_indexes = sorted(
+        {
+            track.get("index")
+            for track in audio_tracks
+            if isinstance(track.get("index"), int)
+        }
+    )
+    if track_index not in valid_indexes:
+        return False
+
+    command = ["mkvpropedit", file_path]
+    for idx in valid_indexes:
+        command.extend(["--edit", f"track:a{idx + 1}", "--set", "flag-default=0"])
+    command.extend(["--edit", f"track:a{track_index + 1}", "--set", "flag-default=1"])
+
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def set_default_track_by_language(file_path: str, audio_tracks: list[dict], language: str) -> bool:
+    """Set the first track matching the language as default for an MKV file."""
+    target_index = find_track_index_for_language(audio_tracks, language)
+    if target_index is None:
+        return False
+    return set_default_track_by_index(file_path, audio_tracks, target_index)

--- a/backend/app/core/preference_engine.py
+++ b/backend/app/core/preference_engine.py
@@ -13,6 +13,7 @@ class AudioPreferences:
     require_dual_audio_anime: bool = True
     check_default_track: bool = True
     preferred_codecs: list[str] = field(default_factory=list)
+    auto_fix_english_default_non_anime: bool = False
 
 
 @dataclass

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -280,6 +280,7 @@ class AudioPreferences(BaseModel):
     require_dual_audio_anime: bool = True
     check_default_track: bool = True
     preferred_codecs: list[str] = []  # Empty = no preference
+    auto_fix_english_default_non_anime: bool = False
 
 
 class AnimeDetectionSettings(BaseModel):
@@ -303,6 +304,19 @@ class UserSettingsUpdate(BaseModel):
     audio_preferences: Optional[AudioPreferences] = None
     anime_detection: Optional[AnimeDetectionSettings] = None
     file_extensions: Optional[list[str]] = None
+
+
+class UpdateDefaultAudioRequest(BaseModel):
+    """Request to set a media file default audio track by language."""
+
+    language: str = Field(min_length=2, max_length=10)
+
+
+class UpdateDefaultAudioResponse(BaseModel):
+    """Response after applying a default audio update."""
+
+    message: str
+    media_file: MediaFileResponse
 
 
 # ============== Stats Schemas ==============

--- a/backend/tests/test_audio_fixer.py
+++ b/backend/tests/test_audio_fixer.py
@@ -1,0 +1,41 @@
+"""Tests for low-level audio default fixer utilities."""
+
+import unittest
+from unittest.mock import patch
+
+from app.core.audio_fixer import (
+    find_track_index_for_language,
+    set_default_track_by_index,
+)
+
+
+class AudioFixerTests(unittest.TestCase):
+    def test_find_track_index_for_language(self):
+        tracks = [
+            {"index": 0, "language": "ja"},
+            {"index": 1, "language": "en"},
+        ]
+
+        self.assertEqual(find_track_index_for_language(tracks, "en"), 1)
+        self.assertIsNone(find_track_index_for_language(tracks, "fr"))
+
+    def test_set_default_track_by_index_builds_command(self):
+        tracks = [
+            {"index": 0, "language": "ja"},
+            {"index": 1, "language": "en"},
+        ]
+
+        with (
+            patch("app.core.audio_fixer.shutil.which", return_value="/usr/bin/mkvpropedit"),
+            patch("app.core.audio_fixer.subprocess.run") as run_mock,
+        ):
+            ok = set_default_track_by_index("/media/movie/file.mkv", tracks, 1)
+
+        self.assertTrue(ok)
+        command = run_mock.call_args.args[0]
+        self.assertIn("track:a1", command)
+        self.assertIn("track:a2", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_scanner_auto_fix.py
+++ b/backend/tests/test_scanner_auto_fix.py
@@ -1,0 +1,97 @@
+"""Tests for automatic default track fixing in scanner."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.core.preference_engine import AudioPreferences
+from app.core.scanner import MediaScanner
+
+
+class MediaScannerAutoFixTests(unittest.TestCase):
+    def setUp(self):
+        self.scanner = MediaScanner(
+            audio_preferences=AudioPreferences(auto_fix_english_default_non_anime=True)
+        )
+
+    def test_get_english_default_fix_index_returns_none_when_english_already_default(self):
+        tracks = [
+            {"index": 0, "language": "en", "is_default": True},
+            {"index": 1, "language": "ja", "is_default": False},
+        ]
+
+        index = self.scanner._get_english_default_fix_index(tracks)
+
+        self.assertIsNone(index)
+
+    def test_get_english_default_fix_index_returns_english_track_when_non_english_default(self):
+        tracks = [
+            {"index": 0, "language": "ja", "is_default": True},
+            {"index": 1, "language": "en", "is_default": False},
+        ]
+
+        index = self.scanner._get_english_default_fix_index(tracks)
+
+        self.assertEqual(index, 1)
+
+    def test_auto_fix_skips_when_setting_disabled(self):
+        scanner = MediaScanner(
+            audio_preferences=AudioPreferences(auto_fix_english_default_non_anime=False)
+        )
+        audio_info = {
+            "audio_tracks": [
+                {"index": 0, "language": "ja", "is_default": True},
+                {"index": 1, "language": "en", "is_default": False},
+            ]
+        }
+
+        with patch("app.core.scanner.set_default_track_by_index") as set_default_mock:
+            result = scanner._auto_fix_default_track(
+                "/media/movies/file.mkv", audio_info, is_anime=False
+            )
+
+        self.assertEqual(result, audio_info)
+        set_default_mock.assert_not_called()
+
+    def test_auto_fix_skips_anime(self):
+        audio_info = {
+            "audio_tracks": [
+                {"index": 0, "language": "ja", "is_default": True},
+                {"index": 1, "language": "en", "is_default": False},
+            ]
+        }
+
+        with patch("app.core.scanner.set_default_track_by_index") as set_default_mock:
+            result = self.scanner._auto_fix_default_track(
+                "/media/anime/episode.mkv", audio_info, is_anime=True
+            )
+
+        self.assertEqual(result, audio_info)
+        set_default_mock.assert_not_called()
+
+    def test_auto_fix_uses_audio_fixer_and_reanalyzes(self):
+        audio_info = {
+            "audio_tracks": [
+                {"index": 0, "language": "ja", "is_default": True},
+                {"index": 1, "language": "en", "is_default": False},
+            ]
+        }
+        refreshed_info = {
+            "audio_tracks": [
+                {"index": 0, "language": "ja", "is_default": False},
+                {"index": 1, "language": "en", "is_default": True},
+            ]
+        }
+
+        self.scanner.analyzer.analyze = MagicMock(return_value=refreshed_info)
+
+        with patch("app.core.scanner.set_default_track_by_index", return_value=True) as fix_mock:
+            result = self.scanner._auto_fix_default_track(
+                "/media/movies/file.mkv", audio_info, is_anime=False
+            )
+
+        self.assertEqual(result, refreshed_info)
+        fix_mock.assert_called_once_with("/media/movies/file.mkv", audio_info["audio_tracks"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -67,6 +67,8 @@ export const mediaApi = {
   getFiles: (params?: { page?: number; page_size?: number; has_issues?: boolean; show_id?: number; search?: string }) =>
     api.get('/api/media/files', { params }),
   getFile: (id: number) => api.get(`/api/media/files/${id}`),
+  updateDefaultAudio: (id: number, language: string) =>
+    api.post(`/api/media/files/${id}/default-audio`, { language }),
 }
 
 // Settings API

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -425,6 +425,32 @@ export default function SettingsPage() {
               </p>
             </div>
           </label>
+
+
+          <label className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              checked={settings?.audio_preferences.auto_fix_english_default_non_anime ?? false}
+              onChange={(e) => {
+                if (!settings) return
+                updateSettings.mutate({
+                  audio_preferences: {
+                    ...settings.audio_preferences,
+                    auto_fix_english_default_non_anime: e.target.checked,
+                  },
+                })
+              }}
+              className="w-4 h-4 text-orange-500 rounded"
+            />
+            <div>
+              <span className="font-medium text-gray-900 dark:text-white">
+                Auto-fix default to English (non-anime)
+              </span>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Automatically set English as default during scans for non-anime files when available
+              </p>
+            </div>
+          </label>
         </div>
       </section>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -112,6 +112,7 @@ export interface AudioPreferences {
   require_dual_audio_anime: boolean
   check_default_track: boolean
   preferred_codecs: string[]
+  auto_fix_english_default_non_anime: boolean
 }
 
 export interface AnimeDetectionSettings {


### PR DESCRIPTION
### Motivation

- Provide a user-configurable way to enable/disable automatic promotion of English audio to the default track for non-anime media so the scanner does not change files without opt-in.
- Preserve anime behavior by excluding anime files from automatic changes and surface a manual action so users can update defaults from the UI when desired.
- Centralize MKV editing logic into a reusable utility to avoid duplicating `mkvpropedit` command construction and make manual updates reliable.

### Description

- Added a new `auto_fix_english_default_non_anime` boolean to audio preference models and dataclasses so auto-fix is configurable (default: off) and surfaced to the frontend types and settings UI (`backend/app/models/schemas.py`, `backend/app/core/preference_engine.py`, `frontend/src/types/index.ts`, `frontend/src/pages/SettingsPage.tsx`).
- Extracted MKV default-track editing into `backend/app/core/audio_fixer.py` with `set_default_track_by_index` and `set_default_track_by_language`, and added a small helper for track-language lookup.
- Updated `MediaScanner` to load per-user audio preferences at scan start and to only run the auto-fix flow when the new toggle is enabled, while still skipping anime and non-MKV files (`backend/app/core/scanner.py`).
- Added a manual API endpoint `POST /api/media/files/{file_id}/default-audio` that uses the audio fixer, re-analyzes the file, refreshes DB audio tracks and re-evaluates issues so the app reflects the change immediately (`backend/app/api/media.py` and new request/response schemas).
- Frontend changes include a settings checkbox for the toggle and per-file buttons in the Files page to invoke the manual default-audio update, plus an API client method `mediaApi.updateDefaultAudio` to call the new endpoint (`frontend/src/pages/SettingsPage.tsx`, `frontend/src/pages/FilesPage.tsx`, `frontend/src/api/client.ts`).
- Added unit tests for the scanner auto-fix behavior and the low-level audio fixer utility to validate selection and command construction (`backend/tests/test_scanner_auto_fix.py`, `backend/tests/test_audio_fixer.py`).

### Testing

- Compiled backend python modules with `python -m compileall backend/app` which succeeded without errors.
- Ran backend unit tests with `cd backend && pytest -q tests/test_scanner_auto_fix.py tests/test_audio_fixer.py tests/test_scanner_run_scan.py` and all tests passed (`8 passed`).
- Built the frontend with `cd frontend && npm run build` and the production build completed successfully; a UI screenshot of the updated Settings page was captured during verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d4f06bd74832f8e11675a529e117c)