### PR TITLE
Preserve library filters and add per-file rescan

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -69,6 +69,7 @@ export const mediaApi = {
   getFile: (id: number) => api.get(`/api/media/files/${id}`),
   updateDefaultAudio: (id: number, language: string) =>
     api.post(`/api/media/files/${id}/default-audio`, { language }),
+  rescanFile: (id: number) => api.post(`/api/media/files/${id}/rescan`),
 }
 
 // Settings API


### PR DESCRIPTION
### Motivation
- Navigating from the Library list to a title and back reset filters/ search/ page, making it inconvenient to triage files; filters should persist across navigation. 
- When fixing issues in files it should be possible to re-analyze a single file without running a full library rescan.

### Description
- Preserve library state by storing `search`, `page`, `media_type` and `has_issues` in the URL query string using `useSearchParams` and carry `location.search` when linking from the library list to show details (`frontend/src/pages/ShowsPage.tsx`, `frontend/src/pages/ShowDetailPage.tsx`).
- Add a backend endpoint `POST /api/media/files/{file_id}/rescan` to re-analyze one file, and refactor the media-file reanalysis into a shared helper ` _refresh_media_file_analysis` used by both the default-audio flow and the new rescan endpoint (`backend/app/api/media.py`).
- Expose `mediaApi.rescanFile` on the frontend and add per-file “Rescan” actions in both the Files page expanded row and Show Detail file rows with loading/error handling and cache invalidation (`frontend/src/api/client.ts`, `frontend/src/pages/FilesPage.tsx`, `frontend/src/pages/ShowDetailPage.tsx`).
- Fix backend timezone import to use `datetime.now(timezone.utc)` to avoid import errors in tests (`backend/app/api/media.py`).

### Testing
- Frontend build: ran `cd frontend && npm run build` and it completed successfully.
- Backend tests: ran `cd backend && pytest -q` and all tests passed (`32 passed, 2 warnings`).
- UI screenshot attempt with Playwright failed due to the Chromium process crashing in this environment (SIGSEGV), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5c41bbf0832f95f84c8fcec2432e)