### PR TITLE
Add series-wide rescan action in show detail

### DIFF
--- a/backend/app/api/media.py
+++ b/backend/app/api/media.py
@@ -25,6 +25,7 @@ from app.models.schemas import (
     DashboardStats,
     UpdateDefaultAudioRequest,
     UpdateDefaultAudioResponse,
+    BulkRescanResponse,
 )
 from app.services.exporter import Exporter
 
@@ -823,6 +824,36 @@ async def rescan_media_file(
     return UpdateDefaultAudioResponse(
         message="File rescan complete.",
         media_file=_build_media_file_response(mf),
+    )
+
+
+@router.post("/shows/{show_id}/rescan", response_model=BulkRescanResponse)
+async def rescan_show_files(
+    show_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    """Re-analyze every media file in a show for the current user."""
+    show_result = await db.execute(
+        select(Show.id).where(Show.id == show_id, Show.user_id == current_user.id)
+    )
+    if show_result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Show not found")
+
+    files_result = await db.execute(
+        select(MediaFile)
+        .options(selectinload(MediaFile.audio_tracks), selectinload(MediaFile.show))
+        .where(MediaFile.show_id == show_id, MediaFile.user_id == current_user.id)
+        .order_by(MediaFile.id)
+    )
+    media_files = files_result.scalars().all()
+
+    for media_file in media_files:
+        await _refresh_media_file_analysis(db, media_file, current_user)
+
+    return BulkRescanResponse(
+        message="Series rescan complete.",
+        files_rescanned=len(media_files),
     )
 
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -319,6 +319,13 @@ class UpdateDefaultAudioResponse(BaseModel):
     media_file: MediaFileResponse
 
 
+class BulkRescanResponse(BaseModel):
+    """Response after bulk rescanning files."""
+
+    message: str
+    files_rescanned: int
+
+
 # ============== Stats Schemas ==============
 
 

--- a/backend/tests/test_user_isolation.py
+++ b/backend/tests/test_user_isolation.py
@@ -99,6 +99,9 @@ async def test_user_cannot_view_or_edit_other_users_show(test_app):
         )
         assert patch_resp.status_code == 404
 
+        rescan_resp = await client.post(f"/api/media/shows/{users['show_b_id']}/rescan")
+        assert rescan_resp.status_code == 404
+
 
 @pytest.mark.anyio
 async def test_user_cannot_access_other_users_scan_locations(test_app):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -73,6 +73,7 @@ export const mediaApi = {
   updateDefaultAudio: (id: number, language: string) =>
     api.post(`/api/media/files/${id}/default-audio`, { language }),
   rescanFile: (id: number) => api.post(`/api/media/files/${id}/rescan`),
+  rescanShow: (id: number) => api.post(`/api/media/shows/${id}/rescan`),
 }
 
 // Settings API

--- a/frontend/src/pages/ShowDetailPage.tsx
+++ b/frontend/src/pages/ShowDetailPage.tsx
@@ -120,6 +120,20 @@ export default function ShowDetailPage() {
     },
   })
 
+
+  const rescanShowMutation = useMutation({
+    mutationFn: () => mediaApi.rescanShow(showId),
+    onSuccess: () => {
+      setRescanError(null)
+      queryClient.invalidateQueries({ queryKey: ['show', id] })
+      queryClient.invalidateQueries({ queryKey: ['season', id, selectedSeason] })
+      queryClient.invalidateQueries({ queryKey: ['files'] })
+    },
+    onError: () => {
+      setRescanError('Failed to rescan series. Please confirm files still exist and try again.')
+    },
+  })
+
   const toggleAnimeMutation = useMutation({
     mutationFn: (isAnime: boolean) =>
       mediaApi.updateShow(showId, { is_anime: isAnime, anime_source: isAnime ? 'manual' : undefined }),
@@ -186,20 +200,30 @@ export default function ShowDetailPage() {
             )}
           </p>
         </div>
-        {/* Only show anime toggle for TV shows */}
-        {show.media_type === 'tv' && (
+        <div className="flex items-center gap-2">
           <button
-            onClick={() => toggleAnimeMutation.mutate(!show.is_anime)}
-            disabled={toggleAnimeMutation.isPending}
-            className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-              show.is_anime
-                ? 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400'
-                : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
-            }`}
+            onClick={() => rescanShowMutation.mutate()}
+            disabled={rescanShowMutation.isPending}
+            className="inline-flex items-center gap-1.5 px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
           >
-            {show.is_anime ? 'Marked as Anime' : 'Mark as Anime'}
+            <RefreshCw className={`w-4 h-4 ${rescanShowMutation.isPending ? 'animate-spin' : ''}`} />
+            Rescan Series
           </button>
-        )}
+          {/* Only show anime toggle for TV shows */}
+          {show.media_type === 'tv' && (
+            <button
+              onClick={() => toggleAnimeMutation.mutate(!show.is_anime)}
+              disabled={toggleAnimeMutation.isPending}
+              className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                show.is_anime
+                  ? 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
+              }`}
+            >
+              {show.is_anime ? 'Marked as Anime' : 'Mark as Anime'}
+            </button>
+          )}
+        </div>
       </div>
 
       {rescanError && (


### PR DESCRIPTION
### Motivation
- Provide a way to rescan an entire series from the library show detail view in addition to the existing per-file rescan action.
- Keep server-side logic consistent by reusing the existing per-file analysis flow for bulk operations.

### Description
- Added a backend endpoint `POST /api/media/shows/{show_id}/rescan` that re-analyzes every media file belonging to the show for the current user and returns a `BulkRescanResponse` with a message and `files_rescanned` count. 
- Introduced `BulkRescanResponse` schema in `backend/app/models/schemas.py` for the new endpoint.
- Exposed `mediaApi.rescanShow(id)` in `frontend/src/api/client.ts` and wired a `rescanShowMutation` in `ShowDetailPage.tsx` to trigger the series rescan and invalidate relevant queries on success.
- Updated the Show detail header UI to include a "Rescan Series" button (with loading and error handling) alongside the existing per-file rescan controls and added a user-isolation test to prevent rescans of other users' shows.

### Testing
- Ran `pytest backend/tests/test_user_isolation.py -q`, which passed (9 passed, 2 warnings).
- Built the frontend with `npm run build` in `frontend/`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a84b97620832f92397518fd934a57)