### PR TITLE
feat: remove unwanted MKV audio tracks

### DIFF
--- a/backend/app/api/media.py
+++ b/backend/app/api/media.py
@@ -25,6 +25,8 @@ from app.models.schemas import (
     DashboardStats,
     UpdateDefaultAudioRequest,
     UpdateDefaultAudioResponse,
+    AudioTrackRemovalRequest,
+    AudioTrackRemovalResponse,
     BulkRescanResponse,
 )
 from app.services.exporter import Exporter
@@ -33,7 +35,12 @@ router = APIRouter()
 
 from app.core.analyzer import AudioAnalyzer
 from app.core.preference_engine import PreferenceEngine, AudioPreferences
-from app.core.audio_fixer import set_default_track_by_language
+from app.core.audio_fixer import (
+    AudioTrackRemovalError,
+    build_keep_audio_track_indices,
+    remove_unwanted_audio_tracks,
+    set_default_track_by_language,
+)
 from app.models.schemas import AudioPreferences as AudioPreferencesSchema
 
 
@@ -190,6 +197,25 @@ async def _load_user_audio_preferences(db: AsyncSession, user_id: int) -> AudioP
     )
 
 
+
+
+async def _load_user_audio_track_keep_languages(db: AsyncSession, user_id: int) -> list[str]:
+    """Load the user's default audio languages to keep during track removal."""
+    result = await db.execute(
+        select(UserPreference).where(
+            UserPreference.user_id == user_id,
+            UserPreference.key == "audio_preferences",
+        )
+    )
+    pref = result.scalar_one_or_none()
+    if not pref or not pref.value:
+        return AudioPreferencesSchema().audio_track_keep_languages
+
+    try:
+        parsed = AudioPreferencesSchema.model_validate_json(pref.value)
+    except Exception:
+        return AudioPreferencesSchema().audio_track_keep_languages
+    return parsed.audio_track_keep_languages
 
 
 async def _refresh_media_file_analysis(db: AsyncSession, mf: MediaFile, current_user: User) -> None:
@@ -798,6 +824,65 @@ async def update_media_file_default_audio(
 
     return UpdateDefaultAudioResponse(
         message=f"Default audio updated to '{target_language}'.",
+        media_file=_build_media_file_response(mf),
+    )
+
+
+@router.post("/files/{file_id}/audio-tracks/remove", response_model=AudioTrackRemovalResponse)
+async def remove_media_file_audio_tracks(
+    file_id: int,
+    request: AudioTrackRemovalRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    """Remove unwanted audio tracks from an MKV file using mkvmerge.
+
+    Users can either provide exact TrackHound audio track indexes to keep or let
+    TrackHound select tracks from language settings. The default language policy
+    keeps English plus undefined tracks (`und`) because undefined could be a
+    useful track until reviewed manually.
+    """
+    result = await db.execute(
+        select(MediaFile)
+        .options(selectinload(MediaFile.audio_tracks), selectinload(MediaFile.show))
+        .where(MediaFile.id == file_id, MediaFile.user_id == current_user.id)
+    )
+    mf = result.scalar_one_or_none()
+
+    if not mf:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Media file not found")
+
+    track_dicts = [_audio_track_to_dict(track) for track in mf.audio_tracks]
+    if not track_dicts:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No audio tracks found")
+
+    keep_track_indices = request.keep_track_indices
+    if keep_track_indices is None:
+        keep_languages = request.keep_languages
+        if keep_languages is None:
+            keep_languages = await _load_user_audio_track_keep_languages(db, current_user.id)
+        keep_track_indices = build_keep_audio_track_indices(
+            track_dicts,
+            keep_languages=keep_languages,
+        )
+
+    try:
+        removal_result = remove_unwanted_audio_tracks(
+            mf.file_path,
+            track_dicts,
+            keep_track_indices=keep_track_indices,
+            keep_backup=request.keep_backup,
+        )
+    except AudioTrackRemovalError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    await _refresh_media_file_analysis(db, mf, current_user)
+
+    return AudioTrackRemovalResponse(
+        message="Audio tracks removed." if removal_result.removed_track_indices else "No audio tracks needed removal.",
+        kept_track_indices=removal_result.kept_track_indices,
+        removed_track_indices=removal_result.removed_track_indices,
+        backup_path=removal_result.backup_path,
         media_file=_build_media_file_response(mf),
     )
 

--- a/backend/app/core/audio_fixer.py
+++ b/backend/app/core/audio_fixer.py
@@ -1,8 +1,25 @@
-"""Utilities for updating media audio default track flags."""
+"""Utilities for updating and pruning MKV audio tracks."""
 
+from dataclasses import dataclass
+import json
 from pathlib import Path
 import shutil
 import subprocess
+
+from app.core.analyzer import normalize_language
+
+
+class AudioTrackRemovalError(RuntimeError):
+    """Raised when an audio track removal request cannot be completed safely."""
+
+
+@dataclass(frozen=True)
+class AudioTrackRemovalResult:
+    """Result metadata for an MKV audio track removal operation."""
+
+    kept_track_indices: list[int]
+    removed_track_indices: list[int]
+    backup_path: str | None
 
 
 def find_track_index_for_language(audio_tracks: list[dict], language: str) -> int | None:
@@ -52,3 +69,195 @@ def set_default_track_by_language(file_path: str, audio_tracks: list[dict], lang
     if target_index is None:
         return False
     return set_default_track_by_index(file_path, audio_tracks, target_index)
+
+
+def _track_language_tokens(track: dict) -> set[str]:
+    """Return normalized language tokens that can match user keep settings."""
+    tokens: set[str] = set()
+    language = track.get("language")
+    language_raw = track.get("language_raw")
+
+    normalized = normalize_language(language)
+    if normalized:
+        tokens.add(normalized.lower())
+
+    if language_raw:
+        raw = str(language_raw).lower().strip()
+        tokens.add(raw)
+        normalized_raw = normalize_language(raw)
+        if normalized_raw:
+            tokens.add(normalized_raw.lower())
+        elif raw == "und":
+            tokens.add("und")
+    elif language is None:
+        tokens.add("und")
+
+    return tokens
+
+
+def _normalize_keep_languages(keep_languages: list[str] | None) -> set[str]:
+    """Normalize user keep language settings to comparable tokens."""
+    if keep_languages is None:
+        keep_languages = ["en", "und"]
+
+    normalized: set[str] = set()
+    for language in keep_languages:
+        raw = (language or "").lower().strip()
+        if not raw:
+            continue
+        if raw == "und":
+            normalized.add("und")
+            continue
+        code = normalize_language(raw)
+        if code:
+            normalized.add(code.lower())
+    return normalized
+
+
+def build_keep_audio_track_indices(
+    audio_tracks: list[dict], keep_languages: list[str] | None = None
+) -> list[int]:
+    """Select audio track indexes to keep from language settings.
+
+    Defaults are intentionally conservative for TrackHound's main use case:
+    keep English plus undefined (`und`) tracks because undefined could be
+    English or otherwise valuable until the user reviews it.
+    """
+    normalized_keep_languages = _normalize_keep_languages(keep_languages)
+    keep_indexes: list[int] = []
+
+    for track in sorted(audio_tracks, key=lambda item: item.get("index", 0)):
+        track_index = track.get("index")
+        if not isinstance(track_index, int):
+            continue
+        if _track_language_tokens(track) & normalized_keep_languages:
+            keep_indexes.append(track_index)
+
+    return keep_indexes
+
+
+def _get_mkvmerge_audio_track_ids(file_path: str) -> list[int]:
+    """Return mkvmerge track IDs for audio tracks, ordered by audio track position."""
+    if shutil.which("mkvmerge") is None:
+        raise AudioTrackRemovalError("mkvmerge is not installed or not on PATH.")
+
+    try:
+        result = subprocess.run(
+            ["mkvmerge", "-J", file_path],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise AudioTrackRemovalError("Unable to inspect MKV tracks with mkvmerge.") from exc
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AudioTrackRemovalError("mkvmerge returned invalid JSON while inspecting tracks.") from exc
+
+    audio_track_ids: list[int] = []
+    for track in payload.get("tracks", []):
+        if track.get("type") == "audio" and isinstance(track.get("id"), int):
+            audio_track_ids.append(track["id"])
+    return audio_track_ids
+
+
+def _build_audio_track_id_selection(
+    file_path: str, audio_tracks: list[dict], keep_track_indices: list[int]
+) -> tuple[list[int], list[int], list[int]]:
+    """Map TrackHound audio indexes to mkvmerge track IDs."""
+    valid_track_indices = sorted(
+        {
+            track.get("index")
+            for track in audio_tracks
+            if isinstance(track.get("index"), int)
+        }
+    )
+    keep_track_indices = sorted(set(keep_track_indices))
+
+    if not keep_track_indices:
+        raise AudioTrackRemovalError("At least one audio track must be kept.")
+
+    unknown_indices = sorted(set(keep_track_indices) - set(valid_track_indices))
+    if unknown_indices:
+        raise AudioTrackRemovalError(
+            f"Requested audio track indexes do not exist: {unknown_indices}."
+        )
+
+    mkvmerge_audio_ids = _get_mkvmerge_audio_track_ids(file_path)
+    if len(mkvmerge_audio_ids) < len(valid_track_indices):
+        raise AudioTrackRemovalError(
+            "mkvmerge reported fewer audio tracks than TrackHound has stored. Rescan the file first."
+        )
+
+    kept_mkvmerge_ids = [mkvmerge_audio_ids[index] for index in keep_track_indices]
+    removed_track_indices = [
+        index for index in valid_track_indices if index not in keep_track_indices
+    ]
+    return keep_track_indices, removed_track_indices, kept_mkvmerge_ids
+
+
+def remove_unwanted_audio_tracks(
+    file_path: str,
+    audio_tracks: list[dict],
+    keep_track_indices: list[int],
+    *,
+    keep_backup: bool = True,
+) -> AudioTrackRemovalResult:
+    """Remux an MKV with only the selected audio tracks kept.
+
+    This uses mkvmerge to write a new file next to the source, then replaces the
+    source only after mkvmerge succeeds. By default the original file is retained
+    as `<filename>.bak` as a fallback.
+    """
+    source = Path(file_path)
+    if source.suffix.lower() != ".mkv":
+        raise AudioTrackRemovalError("Audio track removal currently supports MKV files only.")
+    if not source.exists():
+        raise AudioTrackRemovalError("Media file does not exist on disk.")
+
+    kept_indices, removed_indices, kept_mkvmerge_ids = _build_audio_track_id_selection(
+        file_path, audio_tracks, keep_track_indices
+    )
+    if not removed_indices:
+        return AudioTrackRemovalResult(
+            kept_track_indices=kept_indices,
+            removed_track_indices=[],
+            backup_path=None,
+        )
+
+    temporary_output = source.with_name(f".trackhound-{source.name}")
+    backup_path = source.with_suffix(source.suffix + ".bak") if keep_backup else None
+    command = [
+        "mkvmerge",
+        "-o",
+        str(temporary_output),
+        "--audio-tracks",
+        ",".join(str(track_id) for track_id in kept_mkvmerge_ids),
+        str(source),
+    ]
+
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+        if keep_backup:
+            if backup_path and backup_path.exists():
+                backup_path.unlink()
+            source.replace(backup_path)
+            temporary_output.replace(source)
+        else:
+            temporary_output.replace(source)
+    except subprocess.CalledProcessError as exc:
+        if temporary_output.exists():
+            temporary_output.unlink()
+        raise AudioTrackRemovalError("mkvmerge failed while removing audio tracks.") from exc
+    except OSError as exc:
+        if temporary_output.exists():
+            temporary_output.unlink()
+        raise AudioTrackRemovalError("Unable to replace media file after remuxing.") from exc
+
+    return AudioTrackRemovalResult(
+        kept_track_indices=kept_indices,
+        removed_track_indices=removed_indices,
+        backup_path=str(backup_path) if backup_path else None,
+    )

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -273,7 +273,7 @@ class ShowListResponse(BaseModel):
 
 
 class AudioPreferences(BaseModel):
-    """Audio preference rules."""
+    """User audio preference rules."""
 
     require_english_non_anime: bool = True
     require_japanese_anime: bool = True
@@ -281,6 +281,7 @@ class AudioPreferences(BaseModel):
     check_default_track: bool = True
     preferred_codecs: list[str] = []  # Empty = no preference
     auto_fix_english_default_non_anime: bool = False
+    audio_track_keep_languages: list[str] = ["en", "und"]
 
 
 class AnimeDetectionSettings(BaseModel):
@@ -316,6 +317,24 @@ class UpdateDefaultAudioResponse(BaseModel):
     """Response after applying a default audio update."""
 
     message: str
+    media_file: MediaFileResponse
+
+
+class AudioTrackRemovalRequest(BaseModel):
+    """Request to remove unwanted audio tracks from an MKV file."""
+
+    keep_track_indices: Optional[list[int]] = None
+    keep_languages: Optional[list[str]] = None
+    keep_backup: bool = True
+
+
+class AudioTrackRemovalResponse(BaseModel):
+    """Response after removing unwanted audio tracks from an MKV file."""
+
+    message: str
+    kept_track_indices: list[int]
+    removed_track_indices: list[int]
+    backup_path: Optional[str] = None
     media_file: MediaFileResponse
 
 

--- a/backend/tests/test_audio_track_removal.py
+++ b/backend/tests/test_audio_track_removal.py
@@ -1,0 +1,96 @@
+"""Tests for MKV audio track removal planning and execution."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.core.audio_fixer import (
+    AudioTrackRemovalError,
+    build_keep_audio_track_indices,
+    remove_unwanted_audio_tracks,
+)
+
+
+def test_build_keep_audio_track_indices_defaults_to_english_and_undefined():
+    tracks = [
+        {"index": 0, "language": "ja", "language_raw": "jpn"},
+        {"index": 1, "language": "en", "language_raw": "eng"},
+        {"index": 2, "language": None, "language_raw": "und"},
+        {"index": 3, "language": "es", "language_raw": "spa"},
+    ]
+
+    assert build_keep_audio_track_indices(tracks) == [1, 2]
+
+
+def test_build_keep_audio_track_indices_supports_explicit_user_languages():
+    tracks = [
+        {"index": 0, "language": "ja", "language_raw": "jpn"},
+        {"index": 1, "language": "en", "language_raw": "eng"},
+        {"index": 2, "language": None, "language_raw": "und"},
+    ]
+
+    assert build_keep_audio_track_indices(tracks, keep_languages=["ja"]) == [0]
+
+
+def test_remove_unwanted_audio_tracks_uses_mkvmerge_track_ids_and_keeps_backup(tmp_path):
+    source = tmp_path / "movie.mkv"
+    source.write_text("original", encoding="utf-8")
+    backup = tmp_path / "movie.mkv.bak"
+
+    tracks = [
+        {"index": 0, "language": "ja", "language_raw": "jpn"},
+        {"index": 1, "language": "en", "language_raw": "eng"},
+        {"index": 2, "language": None, "language_raw": "und"},
+    ]
+    mkvmerge_probe = {
+        "tracks": [
+            {"id": 0, "type": "video"},
+            {"id": 1, "type": "audio"},
+            {"id": 2, "type": "audio"},
+            {"id": 3, "type": "subtitles"},
+            {"id": 4, "type": "audio"},
+        ]
+    }
+
+    def fake_run(command, check, capture_output, text):
+        if command[:2] == ["mkvmerge", "-J"]:
+            class Result:
+                stdout = __import__("json").dumps(mkvmerge_probe)
+            return Result()
+        if command[:3] == ["mkvmerge", "-o", str(source.with_name(".trackhound-movie.mkv"))]:
+            Path(command[2]).write_text("remuxed", encoding="utf-8")
+            class Result:
+                stdout = ""
+            return Result()
+        raise AssertionError(f"unexpected command: {command}")
+
+    with (
+        patch("app.core.audio_fixer.shutil.which", return_value="/usr/bin/mkvmerge"),
+        patch("app.core.audio_fixer.subprocess.run", side_effect=fake_run) as run_mock,
+    ):
+        result = remove_unwanted_audio_tracks(str(source), tracks, keep_track_indices=[1, 2])
+
+    assert result.kept_track_indices == [1, 2]
+    assert result.removed_track_indices == [0]
+    assert result.backup_path == str(backup)
+    assert source.read_text(encoding="utf-8") == "remuxed"
+    assert backup.read_text(encoding="utf-8") == "original"
+
+    remux_command = run_mock.call_args_list[1].args[0]
+    assert remux_command == [
+        "mkvmerge",
+        "-o",
+        str(source.with_name(".trackhound-movie.mkv")),
+        "--audio-tracks",
+        "2,4",
+        str(source),
+    ]
+
+
+def test_remove_unwanted_audio_tracks_refuses_to_remove_every_audio_track(tmp_path):
+    source = tmp_path / "movie.mkv"
+    source.write_text("original", encoding="utf-8")
+
+    with pytest.raises(AudioTrackRemovalError, match="At least one audio track"):
+        remove_unwanted_audio_tracks(str(source), [{"index": 0, "language": "en"}], keep_track_indices=[])

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -72,6 +72,10 @@ export const mediaApi = {
   getFile: (id: number) => api.get(`/api/media/files/${id}`),
   updateDefaultAudio: (id: number, language: string) =>
     api.post(`/api/media/files/${id}/default-audio`, { language }),
+  removeAudioTracks: (
+    id: number,
+    data: { keep_track_indices?: number[]; keep_languages?: string[]; keep_backup?: boolean }
+  ) => api.post(`/api/media/files/${id}/audio-tracks/remove`, data),
   rescanFile: (id: number) => api.post(`/api/media/files/${id}/rescan`),
   rescanShow: (id: number) => api.post(`/api/media/shows/${id}/rescan`),
 }

--- a/frontend/src/pages/FilesPage.tsx
+++ b/frontend/src/pages/FilesPage.tsx
@@ -29,6 +29,7 @@ export default function FilesPage() {
   const [hasIssues, setHasIssues] = useState<boolean | undefined>(undefined)
   const [issueCategory, setIssueCategory] = useState<'missing_required_audio' | 'preferred_not_default' | undefined>(undefined)
   const [expandedFile, setExpandedFile] = useState<number | null>(null)
+  const [trackKeepSelections, setTrackKeepSelections] = useState<Record<number, number[]>>({})
   const [actionError, setActionError] = useState<string | null>(null)
   const [isResetting, setIsResetting] = useState(false)
   const queryClient = useQueryClient()
@@ -55,6 +56,19 @@ export default function FilesPage() {
     },
     onError: () => {
       setActionError('Failed to rescan file. Please confirm the file still exists and try again.')
+    },
+  })
+
+  const removeAudioTracks = useMutation({
+    mutationFn: ({ file, keepTrackIndices }: { file: MediaFile; keepTrackIndices: number[] }) =>
+      mediaApi.removeAudioTracks(file.id, { keep_track_indices: keepTrackIndices, keep_backup: true }),
+    onSuccess: () => {
+      setActionError(null)
+      queryClient.invalidateQueries({ queryKey: ['files'] })
+    },
+    onError: (error: unknown) => {
+      const maybeAxiosError = error as { response?: { data?: { detail?: string } } }
+      setActionError(maybeAxiosError.response?.data?.detail || 'Failed to remove audio tracks. Confirm this is an MKV file and mkvmerge is installed.')
     },
   })
 
@@ -130,6 +144,45 @@ export default function FilesPage() {
     if (gb >= 1) return `${gb.toFixed(2)} GB`
     const mb = bytes / (1024 * 1024)
     return `${mb.toFixed(1)} MB`
+  }
+
+  const defaultKeepTrackIndices = (file: MediaFile) =>
+    file.audio_tracks
+      .filter((track) => (track.language || track.language_raw || 'und').toLowerCase() === 'en' || (track.language_raw || '').toLowerCase() === 'und' || !track.language)
+      .map((track) => track.track_index)
+
+  const selectedKeepTrackIndices = (file: MediaFile) =>
+    trackKeepSelections[file.id] ?? defaultKeepTrackIndices(file)
+
+  const toggleKeepTrack = (file: MediaFile, trackIndex: number) => {
+    const selected = new Set(selectedKeepTrackIndices(file))
+    if (selected.has(trackIndex)) {
+      selected.delete(trackIndex)
+    } else {
+      selected.add(trackIndex)
+    }
+    setTrackKeepSelections((prev) => ({
+      ...prev,
+      [file.id]: [...selected].sort((a, b) => a - b),
+    }))
+  }
+
+  const handleRemoveAudioTracks = (file: MediaFile) => {
+    const keepTrackIndices = selectedKeepTrackIndices(file)
+    const removeCount = file.audio_tracks.length - keepTrackIndices.length
+    if (keepTrackIndices.length === 0) {
+      setActionError('Select at least one audio track to keep.')
+      return
+    }
+    if (removeCount <= 0) {
+      setActionError('Select fewer tracks to keep before removing audio tracks.')
+      return
+    }
+    const confirmed = window.confirm(
+      `Remove ${removeCount} audio track${removeCount === 1 ? '' : 's'} from ${file.filename}? TrackHound will keep a .bak fallback beside the original file.`
+    )
+    if (!confirmed) return
+    removeAudioTracks.mutate({ file, keepTrackIndices })
   }
 
   return (
@@ -331,6 +384,46 @@ export default function FilesPage() {
                                 {lang.toUpperCase()}
                               </button>
                             ))}
+                          </div>
+                          <div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3 space-y-3">
+                            <div>
+                              <span className="text-sm font-medium text-amber-800 dark:text-amber-300">Remove audio tracks:</span>
+                              <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">
+                                Select the audio tracks to keep. Default selection keeps English and UND tracks.
+                              </p>
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                              {file.audio_tracks.map((track) => {
+                                const selected = selectedKeepTrackIndices(file).includes(track.track_index)
+                                return (
+                                  <label
+                                    key={track.id}
+                                    className="inline-flex items-center gap-2 px-2.5 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200"
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={selected}
+                                      onChange={() => toggleKeepTrack(file, track.track_index)}
+                                      className="w-3.5 h-3.5 text-orange-500 rounded"
+                                    />
+                                    Keep #{track.track_index} {track.language?.toUpperCase() || track.language_raw?.toUpperCase() || 'UND'}
+                                  </label>
+                                )
+                              })}
+                            </div>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                handleRemoveAudioTracks(file)
+                              }}
+                              disabled={removeAudioTracks.isPending}
+                              className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white"
+                            >
+                              <Trash2 className="w-3.5 h-3.5" />
+                              {removeAudioTracks.isPending && removeAudioTracks.variables?.file.id === file.id
+                                ? 'Removing...'
+                                : 'Remove Unchecked Tracks'}
+                            </button>
                           </div>
                           <div>
                             <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Audio Tracks:</span>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -451,6 +451,52 @@ export default function SettingsPage() {
               </p>
             </div>
           </label>
+
+          <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 space-y-3">
+            <div>
+              <span className="font-medium text-gray-900 dark:text-white">
+                Default audio tracks to keep when removing tracks
+              </span>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Used by the removal tool when you do not manually override track selection. UND stays enabled by default because it can be mislabeled English.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-4">
+              {[
+                { value: 'en', label: 'English' },
+                { value: 'und', label: 'Undefined / UND' },
+                { value: 'ja', label: 'Japanese' },
+              ].map((option) => {
+                const keepLanguages = settings?.audio_preferences.audio_track_keep_languages ?? ['en', 'und']
+                const checked = keepLanguages.includes(option.value)
+                return (
+                  <label key={option.value} className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => {
+                        if (!settings) return
+                        const current = new Set(settings.audio_preferences.audio_track_keep_languages ?? ['en', 'und'])
+                        if (e.target.checked) {
+                          current.add(option.value)
+                        } else {
+                          current.delete(option.value)
+                        }
+                        updateSettings.mutate({
+                          audio_preferences: {
+                            ...settings.audio_preferences,
+                            audio_track_keep_languages: [...current],
+                          },
+                        })
+                      }}
+                      className="w-4 h-4 text-orange-500 rounded"
+                    />
+                    {option.label}
+                  </label>
+                )
+              })}
+            </div>
+          </div>
         </div>
       </section>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -113,6 +113,7 @@ export interface AudioPreferences {
   check_default_track: boolean
   preferred_codecs: string[]
   auto_fix_english_default_non_anime: boolean
+  audio_track_keep_languages: string[]
 }
 
 export interface AnimeDetectionSettings {


### PR DESCRIPTION
## Summary
- Add mkvmerge-backed audio track removal for MKV files
- Let users keep explicit tracks or use default keep languages
- Default keep policy preserves English and UND tracks
- Keep a .bak fallback when replacing the original file
- Add Files page controls for selecting tracks to keep
- Add Settings controls for default keep languages

## Safety
- Refuses to remove every audio track
- Only supports MKV files
- Writes a temporary remux before replacing the source
- Keeps a .bak fallback by default

## Test Plan
- [x] cd backend && python -m pytest -q
- [x] cd frontend && npm run build
- [x] npm --prefix frontend audit --audit-level=moderate