### PR TITLE
Restrict instance access and make MKV editing explicit and recoverable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,13 @@ SECRET_KEY=change-me-in-production-use-openssl-rand-hex-32
 # At-rest token encryption key - generate with: openssl rand -base64 32
 ENCRYPTION_KEY=change-me-trackhound-encryption-key
 
+# Comma-separated numeric Plex account IDs. Empty denies all logins.
+# Sign in once to see your verified account ID in the access-denied message.
+ALLOWED_PLEX_USER_IDS=
+
+# Keep false for scanning only. Editing also needs a writable media mount.
+MEDIA_WRITES_ENABLED=false
+
 # CORS - set to the URL you'll access TrackHound from
 # For Unraid, use your server IP: http://192.168.x.x:8383
 CORS_ORIGINS=http://localhost:8383

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install backend dependencies
         run: python -m pip install -r requirements-dev.txt
 
+      - name: Install media tools for real MKV integration tests
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg mediainfo mkvtoolnix
+
       - name: Run backend tests
         run: python -m pytest -q
 
@@ -59,6 +62,7 @@ jobs:
     needs:
       - backend-tests
       - frontend-build
+      - container-checks
 
     # Don't publish images from pull requests
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -97,3 +101,43 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  container-checks:
+    name: Container and Compose checks
+    runs-on: ubuntu-latest
+    env:
+      # Deliberately synthetic CI-only values, never deployment credentials.
+      SECRET_KEY: ci-only-signing-key-00000000000000000000000000000000
+      ENCRYPTION_KEY: ci-only-encryption-key-000000000000000000000000000
+      ALLOWED_PLEX_USER_IDS: '123'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Validate both Compose configurations
+        run: |
+          docker compose -f docker-compose.yml config --quiet
+          docker compose -f docker-compose.postgres.yml config --quiet
+      - name: Build production image
+        run: docker build -t trackhound:test .
+      - name: Reject direct image startup with default keys
+        run: |
+          if docker run --rm trackhound:test python -c 'from app.config import get_settings; get_settings()'; then
+            exit 1
+          fi
+      - name: Verify native tools and default write policy
+        run: |
+          docker run --rm -e SECRET_KEY -e ENCRYPTION_KEY trackhound:test python -c 'import shutil; from app.core.media_access import get_media_edit_capabilities; assert shutil.which("mkvmerge") and shutil.which("mkvpropedit"); c = get_media_edit_capabilities(); assert not c.set_default_audio and not c.remove_audio_tracks'
+      - name: Verify startup and health endpoint
+        run: |
+          docker run -d --name trackhound-smoke -e SECRET_KEY -e ENCRYPTION_KEY -e ALLOWED_PLEX_USER_IDS trackhound:test
+          for attempt in $(seq 1 30); do
+            if [ "$(docker inspect --format '{{.State.Health.Status}}' trackhound-smoke)" = healthy ]; then
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs trackhound-smoke
+          exit 1
+      - name: Clean up smoke container
+        if: always()
+        run: docker rm -f trackhound-smoke || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ RUN npm run build
 # Production image
 FROM python:3.11-slim
 
-# Install mediainfo
+# Install media inspection and MKV editing tools. Writes remain opt-in.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends mediainfo && \
+    apt-get install -y --no-install-recommends mediainfo mkvtoolnix && \
+    mkvmerge --version && mkvpropedit --version && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -35,7 +36,7 @@ RUN groupadd --gid 1000 appuser && \
 USER appuser
 
 # Environment
-ENV PYTHONUNBUFFERED=1
+ENV PYTHONUNBUFFERED=1 ENVIRONMENT=production MEDIA_WRITES_ENABLED=false
 
 EXPOSE 8000
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Media audio track scanner with Plex integration. Scans your media library to ide
   - Check default audio track settings
 - **Issue Flagging**: Identify and flag files that don't meet your preferences
 - **Export**: Export results to CSV or JSON
+- **Optional MKV Editing**: Change default audio and remove selected tracks, with write access disabled until an administrator enables it
 
 ## Tech Stack
 
@@ -25,7 +26,7 @@ Media audio track scanner with Plex integration. Scans your media library to ide
 - plexapi for Plex integration
 
 ### Frontend
-- React 18 with TypeScript
+- React 19 with TypeScript
 - Tailwind CSS + shadcn/ui
 - TanStack Query for state management
 
@@ -40,13 +41,26 @@ cd TrackHound
 
 # Copy and configure environment
 cp .env.example .env
-# Edit .env with your settings (especially SECRET_KEY)
+# Edit .env with unique SECRET_KEY and ENCRYPTION_KEY values.
+# Generate them separately: openssl rand -hex 32
+# Configure CORS_ORIGINS and the media paths in docker-compose.yml.
 
 # Build and run with Docker Compose
-docker-compose up -d
+docker compose up -d --build
 
 # Access at http://localhost:8383
 ```
+
+Plex sign-in is restricted to the numeric account IDs in `ALLOWED_PLEX_USER_IDS`.
+An empty list denies all accounts. For initial setup, sign in once: the access-denied
+message shows your verified Plex account ID. Add that ID to `.env` (for example,
+`ALLOWED_PLEX_USER_IDS=123456`), then run `docker compose up -d` to recreate the
+container and sign in again. Separate multiple approved IDs with commas. Removing
+an ID and restarting also blocks that account's existing sessions.
+
+The production image refuses to start with default keys or keys shorter than 32
+characters. Existing installations should read the [upgrade and recovery notes](docs/OPERATIONS.md)
+before updating; preserve existing valid encryption keys.
 
 ### Development Setup
 
@@ -62,8 +76,12 @@ source venv/bin/activate  # or `venv\Scripts\activate` on Windows
 # Install dependencies
 pip install -r requirements.txt
 
+# Install MediaInfo and MKVToolNix with your operating system's package manager.
+# The test suite also uses ffmpeg for its real MKV integration test.
+
 # Copy environment file
 cp ../.env.example .env
+# Configure keys and ALLOWED_PLEX_USER_IDS as above.
 
 # Run development server
 uvicorn app.main:app --reload
@@ -98,6 +116,9 @@ npm run build
 ```
 
 The GitHub Actions workflow runs both checks on pushes and pull requests to `master`.
+It also exercises real MKV editing, validates both Compose configurations, and
+checks production container startup and health before publishing an image. Local
+test runs skip the real MKV test if ffmpeg or MKVToolNix is unavailable.
 
 ## Configuration
 
@@ -107,7 +128,11 @@ The GitHub Actions workflow runs both checks on pushes and pull requests to `mas
 |----------|-------------|---------|
 | `DEBUG` | Enable debug mode | `false` |
 | `DATABASE_URL` | Database connection string | SQLite |
-| `SECRET_KEY` | JWT signing key (change in production!) | - |
+| `ENVIRONMENT` | `production`, `development`, or `test`; Docker uses `production` | `development` outside Docker |
+| `SECRET_KEY` | Unique JWT signing key, at least 32 characters in production | Required in production |
+| `ENCRYPTION_KEY` | Key for stored Plex tokens; retain it across upgrades and restores | Required in production |
+| `ALLOWED_PLEX_USER_IDS` | Comma-separated numeric Plex account IDs allowed to use this instance | Empty: all accounts denied |
+| `MEDIA_WRITES_ENABLED` | Permit MKV edits when the tools and filesystem also allow them | `false` |
 | `CORS_ORIGINS` | Allowed CORS origins | `http://localhost:3000,http://localhost:5173` |
 
 ### Database Options
@@ -131,12 +156,30 @@ DATABASE_URL=postgresql+asyncpg://user:password@host:5432/dbname
      - /mnt/user/Media/TV:/media/tv:ro
      - /mnt/user/Media/Anime:/media/anime:ro
    ```
-3. Set secure `SECRET_KEY` and `ENCRYPTION_KEY` values
-4. Access via `http://your-server:8080`
+3. Set secure `SECRET_KEY` and `ENCRYPTION_KEY` values and configure `ALLOWED_PLEX_USER_IDS` using the setup steps above. These are required when running the published image directly, too.
+4. Access via `http://your-server:8383` for the default Compose file, or port `8080` for `docker-compose.postgres.yml`. Set `CORS_ORIGINS` to the address you use.
+
+### Enable media editing
+
+Keep the default read-only mounts for scanning. To enable edits, set
+`MEDIA_WRITES_ENABLED=true` and change only the intended media mount from `:ro`
+to `:rw`. Recreate the container. Its user (UID/GID `1000:1000`) needs file write
+permission; removing tracks also needs directory write permission and enough free
+space for another copy of the media file.
+
+The UI reports why an edit is unavailable, and the API checks access again before
+writing. Track removal starts with your saved keep-language preferences and asks
+you to review the exact tracks. It preserves the original as `<filename>.mkv.bak`
+and refuses to overwrite an existing backup. Default-audio changes edit the MKV
+in place and do not create that backup. See [recovery and editing limits](docs/OPERATIONS.md).
 
 ## API Documentation
 
 When running, visit `/docs` for interactive API documentation (Swagger UI).
+
+API clients that remove tracks by index must send `expected_last_scanned` from
+the file response or `GET /api/media/files/{id}/audio-tracks/plan`. A stale or
+missing revision is rejected so indices from an older scan cannot be reused.
 
 ## Contributing Without Merge Conflicts
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -44,6 +44,18 @@ def create_access_token(user_id: int) -> str:
     return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
 
 
+def require_allowed_plex_user(plex_user_id: str) -> None:
+    """Apply instance authorization to new logins and existing sessions."""
+    if plex_user_id not in settings.allowed_plex_user_ids_set:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "This Plex account is not approved for this TrackHound instance. "
+                f"Ask the administrator to allow Plex account ID {plex_user_id}."
+            ),
+        )
+
+
 async def get_current_user(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -75,6 +87,7 @@ async def get_current_user(
     if user is None:
         raise credentials_exception
 
+    require_allowed_plex_user(user.plex_user_id)
     return user
 
 
@@ -175,6 +188,7 @@ async def complete_plex_login(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="Failed to get user ID from Plex",
             )
+        require_allowed_plex_user(plex_user_id)
         plex_username = plex_user.get("username", plex_user.get("title", "Unknown"))
         plex_email = plex_user.get("email")
         plex_thumb = plex_user.get("thumb")

--- a/backend/app/api/media.py
+++ b/backend/app/api/media.py
@@ -1,6 +1,8 @@
 """Media API endpoints for querying shows, seasons, and files."""
 
+import asyncio
 from datetime import datetime, timezone
+from pathlib import Path
 from math import ceil
 from typing import Annotated, Optional, Literal
 
@@ -27,13 +29,16 @@ from app.models.schemas import (
     UpdateDefaultAudioResponse,
     AudioTrackRemovalRequest,
     AudioTrackRemovalResponse,
+    AudioTrackRemovalPlan,
     BulkRescanResponse,
+    MediaEditCapabilities,
 )
 from app.services.exporter import Exporter
 
 router = APIRouter()
 
-from app.core.analyzer import AudioAnalyzer
+from app.core.analyzer import AudioAnalyzer, AudioAnalysisError, require_successful_analysis
+from app.core.media_access import get_media_edit_capabilities
 from app.core.preference_engine import PreferenceEngine, AudioPreferences
 from app.core.audio_fixer import (
     AudioTrackRemovalError,
@@ -151,6 +156,7 @@ def _build_media_file_response(mf: MediaFile) -> MediaFileResponse:
         has_issues=mf.has_issues,
         issue_details=mf.issue_details,
         audio_tracks=_build_audio_track_responses(mf.audio_tracks),
+        edit_capabilities=get_media_edit_capabilities(mf.file_path),
     )
 
 
@@ -221,7 +227,19 @@ async def _load_user_audio_track_keep_languages(db: AsyncSession, user_id: int) 
 async def _refresh_media_file_analysis(db: AsyncSession, mf: MediaFile, current_user: User) -> None:
     """Re-analyze one media file and refresh audio track + issue metadata."""
     analyzer = AudioAnalyzer()
-    refreshed_audio = analyzer.analyze(mf.file_path)
+    try:
+        before = Path(mf.file_path).stat()
+        refreshed_audio = require_successful_analysis(
+            await asyncio.to_thread(analyzer.analyze, mf.file_path)
+        )
+        after = Path(mf.file_path).stat()
+        if (before.st_ino, before.st_size, before.st_mtime_ns) != (after.st_ino, after.st_size, after.st_mtime_ns):
+            raise AudioAnalysisError("File changed during analysis. Please rescan it again.")
+    except (AudioAnalysisError, OSError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Analysis could not be refreshed; previous metadata was preserved. {exc}",
+        ) from exc
     refreshed_tracks = refreshed_audio.get("audio_tracks", [])
 
     await db.execute(delete(AudioTrack).where(AudioTrack.media_file_id == mf.id))
@@ -245,6 +263,8 @@ async def _refresh_media_file_analysis(db: AsyncSession, mf: MediaFile, current_
     mf.container_format = refreshed_audio.get("container")
     mf.duration_ms = refreshed_audio.get("duration_ms")
     mf.last_scanned = datetime.now(timezone.utc)
+    mf.file_size = after.st_size
+    mf.last_modified = datetime.fromtimestamp(after.st_mtime)
 
     audio_preferences = await _load_user_audio_preferences(db, current_user.id)
     preference_engine = PreferenceEngine(audio_preferences)
@@ -257,6 +277,27 @@ async def _refresh_media_file_analysis(db: AsyncSession, mf: MediaFile, current_
     await db.refresh(mf, attribute_names=["audio_tracks", "show"])
 
 # ============== Dashboard Stats ==============
+
+
+@router.get("/capabilities", response_model=MediaEditCapabilities)
+async def media_edit_capabilities(
+    current_user: Annotated[User, Depends(get_current_user)],
+):
+    """Report instance-level editing capabilities; files may have stricter access."""
+    return get_media_edit_capabilities()
+
+
+def _require_editable_current_file(mf: MediaFile, operation: Literal["default", "remove"]) -> None:
+    capabilities = get_media_edit_capabilities(mf.file_path)
+    reason = capabilities.default_audio_reason if operation == "default" else capabilities.track_removal_reason
+    if reason:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=reason)
+    try:
+        stat = Path(mf.file_path).stat()
+    except OSError as exc:
+        raise HTTPException(status_code=409, detail="The media file is unavailable. Rescan before editing.") from exc
+    if stat.st_size != mf.file_size or datetime.fromtimestamp(stat.st_mtime) != mf.last_modified:
+        raise HTTPException(status_code=409, detail="The file has changed since its last scan. Rescan before editing.")
 
 
 @router.get("/stats", response_model=DashboardStats)
@@ -809,22 +850,52 @@ async def update_media_file_default_audio(
     if not mf:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Media file not found")
 
+    _require_editable_current_file(mf, "default")
     target_language = request.language.strip().lower()
     track_dicts = [_audio_track_to_dict(track) for track in mf.audio_tracks]
     if not track_dicts:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No audio tracks found")
 
-    if not set_default_track_by_language(mf.file_path, track_dicts, target_language):
+    if not await asyncio.to_thread(set_default_track_by_language, mf.file_path, track_dicts, target_language):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Unable to set default audio track. Ensure the file is MKV, mkvpropedit is installed, and the language exists.",
         )
 
-    await _refresh_media_file_analysis(db, mf, current_user)
+    try:
+        await _refresh_media_file_analysis(db, mf, current_user)
+    except HTTPException as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail=f"Default audio was updated, but its metadata could not be refreshed. Rescan before editing again. {exc.detail}",
+        ) from exc
 
     return UpdateDefaultAudioResponse(
         message=f"Default audio updated to '{target_language}'.",
         media_file=_build_media_file_response(mf),
+    )
+
+
+@router.get("/files/{file_id}/audio-tracks/plan", response_model=AudioTrackRemovalPlan)
+async def plan_media_file_audio_tracks(
+    file_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    result = await db.execute(
+        select(MediaFile).options(selectinload(MediaFile.audio_tracks))
+        .where(MediaFile.id == file_id, MediaFile.user_id == current_user.id)
+    )
+    mf = result.scalar_one_or_none()
+    if not mf:
+        raise HTTPException(status_code=404, detail="Media file not found")
+    keep_languages = await _load_user_audio_track_keep_languages(db, current_user.id)
+    return AudioTrackRemovalPlan(
+        file_id=mf.id,
+        last_scanned=mf.last_scanned,
+        keep_track_indices=build_keep_audio_track_indices(
+            [_audio_track_to_dict(track) for track in mf.audio_tracks], keep_languages
+        ),
     )
 
 
@@ -852,11 +923,18 @@ async def remove_media_file_audio_tracks(
     if not mf:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Media file not found")
 
+    _require_editable_current_file(mf, "remove")
     track_dicts = [_audio_track_to_dict(track) for track in mf.audio_tracks]
     if not track_dicts:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No audio tracks found")
 
     keep_track_indices = request.keep_track_indices
+    if keep_track_indices is not None:
+        expected = request.expected_last_scanned
+        if expected is not None and expected.tzinfo is not None:
+            expected = expected.astimezone(timezone.utc).replace(tzinfo=None)
+        if expected is None or expected.replace(tzinfo=None) != mf.last_scanned.replace(tzinfo=None):
+            raise HTTPException(status_code=409, detail="The track selection is out of date. Refresh the file and review the tracks again.")
     if keep_track_indices is None:
         keep_languages = request.keep_languages
         if keep_languages is None:
@@ -867,7 +945,8 @@ async def remove_media_file_audio_tracks(
         )
 
     try:
-        removal_result = remove_unwanted_audio_tracks(
+        removal_result = await asyncio.to_thread(
+            remove_unwanted_audio_tracks,
             mf.file_path,
             track_dicts,
             keep_track_indices=keep_track_indices,
@@ -876,7 +955,16 @@ async def remove_media_file_audio_tracks(
     except AudioTrackRemovalError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
-    await _refresh_media_file_analysis(db, mf, current_user)
+    try:
+        await _refresh_media_file_analysis(db, mf, current_user)
+    except HTTPException as exc:
+        if not removal_result.removed_track_indices:
+            raise
+        backup_note = f" Original backup: {removal_result.backup_path}." if removal_result.backup_path else ""
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail=f"Audio tracks were removed, but metadata could not be refreshed. Rescan before editing again.{backup_note} {exc.detail}",
+        ) from exc
 
     return AudioTrackRemovalResponse(
         message="Audio tracks removed." if removal_result.removed_track_indices else "No audio tracks needed removal.",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -5,6 +5,7 @@ import warnings
 from functools import lru_cache
 from typing import Literal
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,8 @@ class Settings(BaseSettings):
     encryption_key: str = _INSECURE_DEFAULT_ENCRYPTION_KEY
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 60 * 24 * 7  # 1 week
+    allowed_plex_user_ids: str = ""
+    media_writes_enabled: bool = False
 
     # Plex OAuth
     plex_client_identifier: str = "trackhound"
@@ -54,29 +57,42 @@ class Settings(BaseSettings):
 
     def validate_secret_key(self) -> None:
         """Warn or raise if the secret key is insecure."""
-        if self.secret_key == _INSECURE_DEFAULT_KEY:
+        if self.secret_key == _INSECURE_DEFAULT_KEY or len(self.secret_key.strip()) < 32:
             if self.environment == "production":
                 raise ValueError(
-                    "SECRET_KEY must be set to a secure value in production. "
+                    "SECRET_KEY must be a non-default value of at least 32 characters in production. "
                     "Generate one with: openssl rand -hex 32"
                 )
             warnings.warn(
-                "Using default SECRET_KEY — set a secure value before deploying. "
+                "Using default or short SECRET_KEY — set a secure value before deploying. "
                 "Generate one with: openssl rand -hex 32",
                 stacklevel=2,
             )
 
-        if self.encryption_key == _INSECURE_DEFAULT_ENCRYPTION_KEY:
+        if self.encryption_key == _INSECURE_DEFAULT_ENCRYPTION_KEY or len(self.encryption_key.strip()) < 32:
             if self.environment == "production":
                 raise ValueError(
-                    "ENCRYPTION_KEY must be set to a secure value in production. "
+                    "ENCRYPTION_KEY must be a non-default value of at least 32 characters in production. "
                     "Generate one with: openssl rand -base64 32"
                 )
             warnings.warn(
-                "Using default ENCRYPTION_KEY — set a secure value before deploying. "
+                "Using default or short ENCRYPTION_KEY — set a secure value before deploying. "
                 "Generate one with: openssl rand -base64 32",
                 stacklevel=2,
             )
+
+    @field_validator("allowed_plex_user_ids")
+    @classmethod
+    def validate_allowed_plex_user_ids(cls, value: str) -> str:
+        ids = [item.strip() for item in value.split(",") if item.strip()]
+        if any(not item.isascii() or not item.isdecimal() or int(item) <= 0 for item in ids):
+            raise ValueError("ALLOWED_PLEX_USER_IDS must contain comma-separated positive numeric Plex account IDs")
+        return ",".join(dict.fromkeys(str(int(item)) for item in ids))
+
+    @property
+    def allowed_plex_user_ids_set(self) -> set[str]:
+        """An empty allowlist deliberately grants no account access."""
+        return set(filter(None, self.allowed_plex_user_ids.split(",")))
 
     @property
     def cors_origins_list(self) -> list[str]:

--- a/backend/app/core/analyzer.py
+++ b/backend/app/core/analyzer.py
@@ -2,6 +2,18 @@
 
 from typing import Optional
 
+
+class AudioAnalysisError(RuntimeError):
+    """The file could not be analyzed; existing metadata must be retained."""
+
+
+def require_successful_analysis(result: dict) -> dict:
+    """Do not interpret a failed or skipped probe as a file with no audio."""
+    problem = result.get("error") or result.get("warning")
+    if problem:
+        raise AudioAnalysisError(f"Audio analysis failed: {problem}")
+    return result
+
 # Language code mappings
 LANGUAGE_MAP = {
     # ISO 639-2 to ISO 639-1
@@ -106,8 +118,7 @@ class AudioAnalyzer:
             try:
                 from pymediainfo import MediaInfo
                 # Try to parse nothing to see if libmediainfo is installed
-                MediaInfo.can_parse()
-                self._mediainfo_available = True
+                self._mediainfo_available = bool(MediaInfo.can_parse())
             except Exception:
                 self._mediainfo_available = False
         return self._mediainfo_available

--- a/backend/app/core/audio_fixer.py
+++ b/backend/app/core/audio_fixer.py
@@ -2,11 +2,21 @@
 
 from dataclasses import dataclass
 import json
+import logging
+import os
 from pathlib import Path
 import shutil
 import subprocess
+import tempfile
+from threading import Lock
 
 from app.core.analyzer import normalize_language
+
+_edit_lock = Lock()
+logger = logging.getLogger(__name__)
+PROBE_TIMEOUT_SECONDS = 30
+DEFAULT_EDIT_TIMEOUT_SECONDS = 60
+REMUX_TIMEOUT_SECONDS = 3600
 
 
 class AudioTrackRemovalError(RuntimeError):
@@ -35,6 +45,15 @@ def find_track_index_for_language(audio_tracks: list[dict], language: str) -> in
 
 def set_default_track_by_index(file_path: str, audio_tracks: list[dict], track_index: int) -> bool:
     """Set the provided audio track index as default for an MKV file."""
+    if not _edit_lock.acquire(blocking=False):
+        return False
+    try:
+        return _set_default_track_by_index(file_path, audio_tracks, track_index)
+    finally:
+        _edit_lock.release()
+
+
+def _set_default_track_by_index(file_path: str, audio_tracks: list[dict], track_index: int) -> bool:
     if Path(file_path).suffix.lower() != ".mkv":
         return False
 
@@ -57,9 +76,9 @@ def set_default_track_by_index(file_path: str, audio_tracks: list[dict], track_i
     command.extend(["--edit", f"track:a{track_index + 1}", "--set", "flag-default=1"])
 
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True)
+        subprocess.run(command, check=True, capture_output=True, text=True, timeout=DEFAULT_EDIT_TIMEOUT_SECONDS)
         return True
-    except subprocess.CalledProcessError:
+    except (subprocess.SubprocessError, OSError):
         return False
 
 
@@ -147,8 +166,9 @@ def _get_mkvmerge_audio_track_ids(file_path: str) -> list[int]:
             check=True,
             capture_output=True,
             text=True,
+            timeout=PROBE_TIMEOUT_SECONDS,
         )
-    except subprocess.CalledProcessError as exc:
+    except (subprocess.SubprocessError, OSError) as exc:
         raise AudioTrackRemovalError("Unable to inspect MKV tracks with mkvmerge.") from exc
 
     try:
@@ -186,9 +206,9 @@ def _build_audio_track_id_selection(
         )
 
     mkvmerge_audio_ids = _get_mkvmerge_audio_track_ids(file_path)
-    if len(mkvmerge_audio_ids) < len(valid_track_indices):
+    if valid_track_indices != list(range(len(valid_track_indices))) or len(mkvmerge_audio_ids) != len(valid_track_indices):
         raise AudioTrackRemovalError(
-            "mkvmerge reported fewer audio tracks than TrackHound has stored. Rescan the file first."
+            "The file's audio tracks do not match the stored analysis. Rescan the file first."
         )
 
     kept_mkvmerge_ids = [mkvmerge_audio_ids[index] for index in keep_track_indices]
@@ -205,6 +225,24 @@ def remove_unwanted_audio_tracks(
     *,
     keep_backup: bool = True,
 ) -> AudioTrackRemovalResult:
+    """Serialize edits within the single-worker application process."""
+    if not _edit_lock.acquire(blocking=False):
+        raise AudioTrackRemovalError("Another media edit is in progress. Try again when it finishes.")
+    try:
+        return _remove_unwanted_audio_tracks(file_path, audio_tracks, keep_track_indices, keep_backup=keep_backup)
+    except OSError as exc:
+        raise AudioTrackRemovalError("Unable to access the media file, create temporary output, or clean up an edit.") from exc
+    finally:
+        _edit_lock.release()
+
+
+def _remove_unwanted_audio_tracks(
+    file_path: str,
+    audio_tracks: list[dict],
+    keep_track_indices: list[int],
+    *,
+    keep_backup: bool,
+) -> AudioTrackRemovalResult:
     """Remux an MKV with only the selected audio tracks kept.
 
     This uses mkvmerge to write a new file next to the source, then replaces the
@@ -216,6 +254,7 @@ def remove_unwanted_audio_tracks(
         raise AudioTrackRemovalError("Audio track removal currently supports MKV files only.")
     if not source.exists():
         raise AudioTrackRemovalError("Media file does not exist on disk.")
+    source_stat = source.stat()
 
     kept_indices, removed_indices, kept_mkvmerge_ids = _build_audio_track_id_selection(
         file_path, audio_tracks, keep_track_indices
@@ -227,8 +266,13 @@ def remove_unwanted_audio_tracks(
             backup_path=None,
         )
 
-    temporary_output = source.with_name(f".trackhound-{source.name}")
     backup_path = source.with_suffix(source.suffix + ".bak") if keep_backup else None
+    if backup_path and (backup_path.exists() or backup_path.is_symlink()):
+        raise AudioTrackRemovalError("A .bak file already exists. Preserve or move that backup before editing again.")
+    # Exclusive creation avoids collisions with another run or an existing file.
+    fd, temporary_name = tempfile.mkstemp(prefix=".trackhound-", suffix=".mkv", dir=source.parent)
+    os.close(fd)
+    temporary_output = Path(temporary_name)
     command = [
         "mkvmerge",
         "-o",
@@ -238,23 +282,46 @@ def remove_unwanted_audio_tracks(
         str(source),
     ]
 
+    backup_reserved = False
+    source_moved = False
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True)
-        if keep_backup:
-            if backup_path and backup_path.exists():
-                backup_path.unlink()
+        subprocess.run(command, check=True, capture_output=True, text=True, timeout=REMUX_TIMEOUT_SECONDS)
+        if not temporary_output.stat().st_size or len(_get_mkvmerge_audio_track_ids(str(temporary_output))) != len(kept_indices):
+            raise AudioTrackRemovalError("The remuxed file failed verification. The original was retained.")
+        current_stat = source.stat()
+        if (source_stat.st_ino, source_stat.st_size, source_stat.st_mtime_ns) != (current_stat.st_ino, current_stat.st_size, current_stat.st_mtime_ns):
+            raise AudioTrackRemovalError("The source file changed during remuxing. Rescan before editing again.")
+        shutil.copymode(source, temporary_output)
+        if backup_path:
+            # Reserve without overwriting any existing backup, including symlinks.
+            with backup_path.open("xb"):
+                pass
+            backup_reserved = True
             source.replace(backup_path)
+            source_moved = True
             temporary_output.replace(source)
         else:
             temporary_output.replace(source)
-    except subprocess.CalledProcessError as exc:
-        if temporary_output.exists():
-            temporary_output.unlink()
-        raise AudioTrackRemovalError("mkvmerge failed while removing audio tracks.") from exc
+    except subprocess.SubprocessError as exc:
+        raise AudioTrackRemovalError("Audio-track removal failed or timed out. The original was retained.") from exc
     except OSError as exc:
-        if temporary_output.exists():
-            temporary_output.unlink()
-        raise AudioTrackRemovalError("Unable to replace media file after remuxing.") from exc
+        if source_moved and backup_path:
+            try:
+                if source.exists():
+                    raise FileExistsError("A different file now occupies the source path")
+                backup_path.replace(source)
+            except OSError as restore_error:
+                raise AudioTrackRemovalError(
+                    f"Replacement and automatic restoration failed. The original is preserved at {backup_path}."
+                ) from restore_error
+        elif backup_reserved and backup_path:
+            backup_path.unlink()
+        raise AudioTrackRemovalError("Unable to replace media file. The original was retained or restored.") from exc
+    finally:
+        try:
+            temporary_output.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("Unable to remove remux temporary output: %s", temporary_output)
 
     return AudioTrackRemovalResult(
         kept_track_indices=kept_indices,

--- a/backend/app/core/media_access.py
+++ b/backend/app/core/media_access.py
@@ -1,0 +1,44 @@
+"""Instance policy and live filesystem checks for media mutations."""
+
+import os
+from pathlib import Path
+import shutil
+
+from app.config import get_settings
+from app.models.schemas import MEDIA_ROOT, MediaEditCapabilities
+
+
+def get_media_edit_capabilities(file_path: str | None = None) -> MediaEditCapabilities:
+    """Evaluate capabilities again at write time; UI state is only advisory."""
+    reason = None
+    parent_writable = True
+    if not get_settings().media_writes_enabled:
+        reason = "Media editing is disabled by the server administrator."
+    elif file_path is not None:
+        try:
+            path = Path(file_path).resolve(strict=True)
+            path.relative_to(MEDIA_ROOT)
+            if not path.is_file() or path.suffix.lower() != ".mkv":
+                reason = "Only existing MKV files can be edited."
+            elif not os.access(path, os.R_OK | os.W_OK):
+                reason = "The media file is read-only or inaccessible."
+            parent_writable = os.access(path.parent, os.W_OK | os.X_OK)
+        except (OSError, ValueError):
+            reason = "The file is unavailable or outside the permitted media directory."
+
+    default_reason = reason
+    removal_reason = reason
+    if reason is None:
+        if shutil.which("mkvpropedit") is None:
+            default_reason = "The server's default-audio editing tool is unavailable."
+        if shutil.which("mkvmerge") is None:
+            removal_reason = "The server's audio-track removal tool is unavailable."
+        elif not parent_writable:
+            removal_reason = "The media directory is read-only or inaccessible."
+
+    return MediaEditCapabilities(
+        set_default_audio=default_reason is None,
+        remove_audio_tracks=removal_reason is None,
+        default_audio_reason=default_reason,
+        track_removal_reason=removal_reason,
+    )

--- a/backend/app/core/scanner.py
+++ b/backend/app/core/scanner.py
@@ -12,7 +12,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.database import async_session_maker
 from app.models.entities import MediaFile, Show, Season, ScanLocation, UserPreference
-from app.core.analyzer import AudioAnalyzer
+from app.core.analyzer import AudioAnalyzer, require_successful_analysis
+from app.core.media_access import get_media_edit_capabilities
 from app.core.plex_connector import PlexConnector
 from app.core.preference_engine import PreferenceEngine, AudioPreferences
 from app.core.audio_fixer import set_default_track_by_index
@@ -144,6 +145,9 @@ class MediaScanner:
         if is_anime or not audio_tracks:
             return audio_info
 
+        if not get_media_edit_capabilities(file_path).set_default_audio:
+            return audio_info
+
         english_index = self._get_english_default_fix_index(audio_tracks)
         if english_index is None:
             return audio_info
@@ -165,6 +169,8 @@ class MediaScanner:
 
         for root, _, filenames in os.walk(location_path):
             for filename in filenames:
+                if filename.startswith(".trackhound-"):
+                    continue
                 ext = Path(filename).suffix.lower()
                 if ext in self.extensions:
                     files.append(os.path.join(root, filename))
@@ -202,7 +208,7 @@ class MediaScanner:
                 return existing
 
             # Analyze audio tracks
-            audio_info = self.analyzer.analyze(file_path)
+            audio_info = require_successful_analysis(self.analyzer.analyze(file_path))
 
             # Determine title and metadata based on media type
             if is_movie:
@@ -236,10 +242,10 @@ class MediaScanner:
                 thumb_url = None
 
             # Automatically fix default audio for non-anime content when possible
-            audio_info = self._auto_fix_default_track(
-                file_path=file_path,
-                audio_info=audio_info,
-                is_anime=is_anime,
+            audio_info = require_successful_analysis(
+                self._auto_fix_default_track(
+                    file_path=file_path, audio_info=audio_info, is_anime=is_anime,
+                )
             )
 
             # Find or create show

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -173,6 +173,15 @@ class AudioTrackResponse(BaseModel):
 # ============== Media File Schemas ==============
 
 
+class MediaEditCapabilities(BaseModel):
+    """Available file edits and actionable reasons when disabled."""
+
+    set_default_audio: bool
+    remove_audio_tracks: bool
+    default_audio_reason: Optional[str] = None
+    track_removal_reason: Optional[str] = None
+
+
 class MediaFileResponse(BaseModel):
     """Media file information."""
 
@@ -190,6 +199,7 @@ class MediaFileResponse(BaseModel):
     has_issues: bool
     issue_details: Optional[str] = None
     audio_tracks: list[AudioTrackResponse] = []
+    edit_capabilities: Optional[MediaEditCapabilities] = None
 
 
 class MediaFileListResponse(BaseModel):
@@ -326,6 +336,15 @@ class AudioTrackRemovalRequest(BaseModel):
     keep_track_indices: Optional[list[int]] = None
     keep_languages: Optional[list[str]] = None
     keep_backup: bool = True
+    expected_last_scanned: Optional[datetime] = None
+
+
+class AudioTrackRemovalPlan(BaseModel):
+    """Default selection computed from the user's saved policy."""
+
+    file_id: int
+    last_scanned: datetime
+    keep_track_indices: list[int]
 
 
 class AudioTrackRemovalResponse(BaseModel):

--- a/backend/tests/test_audio_track_removal.py
+++ b/backend/tests/test_audio_track_removal.py
@@ -53,12 +53,14 @@ def test_remove_unwanted_audio_tracks_uses_mkvmerge_track_ids_and_keeps_backup(t
         ]
     }
 
-    def fake_run(command, check, capture_output, text):
+    def fake_run(command, check, capture_output, text, timeout):
         if command[:2] == ["mkvmerge", "-J"]:
             class Result:
-                stdout = __import__("json").dumps(mkvmerge_probe)
+                stdout = __import__("json").dumps(mkvmerge_probe if command[2] == str(source) else {
+                    "tracks": [{"id": 0, "type": "video"}, {"id": 1, "type": "audio"}, {"id": 2, "type": "audio"}]
+                })
             return Result()
-        if command[:3] == ["mkvmerge", "-o", str(source.with_name(".trackhound-movie.mkv"))]:
+        if command[:2] == ["mkvmerge", "-o"]:
             Path(command[2]).write_text("remuxed", encoding="utf-8")
             class Result:
                 stdout = ""
@@ -81,11 +83,13 @@ def test_remove_unwanted_audio_tracks_uses_mkvmerge_track_ids_and_keeps_backup(t
     assert remux_command == [
         "mkvmerge",
         "-o",
-        str(source.with_name(".trackhound-movie.mkv")),
+        remux_command[2],
         "--audio-tracks",
         "2,4",
         str(source),
     ]
+    assert Path(remux_command[2]).name.startswith(".trackhound-")
+    assert not Path(remux_command[2]).exists()
 
 
 def test_remove_unwanted_audio_tracks_refuses_to_remove_every_audio_track(tmp_path):

--- a/backend/tests/test_instance_security.py
+++ b/backend/tests/test_instance_security.py
@@ -1,0 +1,97 @@
+"""Production configuration and authorization at the Plex trust boundary."""
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.api import auth
+from app.config import Settings, _INSECURE_DEFAULT_KEY, _INSECURE_DEFAULT_ENCRYPTION_KEY
+from app.models.entities import Base, User
+
+
+@pytest.mark.parametrize("field,bad_value", [
+    ("secret_key", _INSECURE_DEFAULT_KEY),
+    ("secret_key", ""),
+    ("secret_key", " " * 64),
+    ("secret_key", "too-short"),
+    ("encryption_key", _INSECURE_DEFAULT_ENCRYPTION_KEY),
+    ("encryption_key", ""),
+    ("encryption_key", "too-short"),
+])
+def test_production_rejects_insecure_keys(field, bad_value):
+    values = {"secret_key": "s" * 64, "encryption_key": "e" * 44, field: bad_value}
+    settings = Settings(environment="production", _env_file=None, **values)
+    with pytest.raises(ValueError, match=field.upper()):
+        settings.validate_secret_key()
+
+
+def test_production_accepts_configured_keys():
+    Settings(environment="production", secret_key="s" * 64, encryption_key="e" * 44, _env_file=None).validate_secret_key()
+
+
+def test_allowlist_normalizes_ids_and_defaults_to_no_access():
+    assert Settings(allowed_plex_user_ids="", _env_file=None).allowed_plex_user_ids_set == set()
+    assert Settings(allowed_plex_user_ids=" 123,00456,123 ", _env_file=None).allowed_plex_user_ids_set == {"123", "456"}
+
+
+@pytest.mark.parametrize("value", ["*", "username", "-1", "0", "12.3", "123,abc"])
+def test_allowlist_rejects_non_account_ids(value):
+    with pytest.raises(ValueError, match="numeric Plex account IDs"):
+        Settings(allowed_plex_user_ids=value, _env_file=None)
+
+
+@pytest_asyncio.fixture
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with async_sessionmaker(engine, expire_on_commit=False)() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("allowed", ["", "456", "123"])
+async def test_plex_login_requires_instance_authorization(monkeypatch, db, allowed):
+    monkeypatch.setattr(auth.settings, "allowed_plex_user_ids", allowed)
+    plex = AsyncMock()
+    plex.get.side_effect = [
+        httpx.Response(200, json={"authToken": "synthetic-plex-token"}),
+        httpx.Response(200, json={"id": 123, "username": "approved-user"}),
+    ]
+    context = AsyncMock()
+    context.__aenter__.return_value = plex
+    monkeypatch.setattr(auth.httpx, "AsyncClient", lambda: context)
+
+    if allowed == "123":
+        response = await auth.complete_plex_login(pin_id=1, db=db)
+        assert response.access_token
+        user = (await db.execute(select(User))).scalar_one()
+        assert user.plex_user_id == "123"
+        assert user.plex_token.startswith("enc::")
+    else:
+        with pytest.raises(HTTPException) as exc:
+            await auth.complete_plex_login(pin_id=1, db=db)
+        assert exc.value.status_code == 403
+        assert "123" in exc.value.detail  # Safe first-install account discovery.
+        assert await db.scalar(select(func.count(User.id))) == 0
+
+
+@pytest.mark.asyncio
+async def test_removing_allowlist_entry_revokes_existing_session(monkeypatch, db):
+    user = User(plex_user_id="123", plex_username="user", plex_token="test")
+    db.add(user)
+    await db.flush()
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=auth.create_access_token(user.id))
+    monkeypatch.setattr(auth.settings, "allowed_plex_user_ids", "123")
+    assert await auth.get_current_user(credentials, db) is user
+    monkeypatch.setattr(auth.settings, "allowed_plex_user_ids", "")
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_user(credentials, db)
+    assert exc.value.status_code == 403

--- a/backend/tests/test_media_edit_safety.py
+++ b/backend/tests/test_media_edit_safety.py
@@ -1,0 +1,212 @@
+"""Failure cases must not mutate media or discard a successful prior analysis."""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.orm import selectinload
+
+from app.api import media
+from app.config import get_settings
+from app.core import media_access
+from app.core.scan_state import scan_state_manager
+from app.core.scanner import MediaScanner
+from app.core.audio_fixer import AudioTrackRemovalResult
+from app.models.entities import Base, User, MediaFile, AudioTrack, UserPreference
+from app.models.schemas import AudioTrackRemovalRequest, UpdateDefaultAudioRequest
+
+
+@pytest_asyncio.fixture
+async def scanned_file(tmp_path):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    source = tmp_path / "movie.mkv"
+    source.write_bytes(b"synthetic media; probes are mocked")
+    async with async_sessionmaker(engine, expire_on_commit=False)() as db:
+        user = User(plex_user_id="123", plex_username="user", plex_token="test")
+        db.add(user)
+        await db.flush()
+        mf = MediaFile(user_id=user.id, file_path=str(source), filename=source.name,
+                       file_size=source.stat().st_size, last_modified=datetime.fromtimestamp(source.stat().st_mtime),
+                       container_format="Matroska", duration_ms=1000, has_issues=False)
+        db.add(mf)
+        await db.flush()
+        db.add_all([
+            AudioTrack(media_file_id=mf.id, track_index=0, language="en", language_raw="eng", is_default=True),
+            AudioTrack(media_file_id=mf.id, track_index=1, language="ja", language_raw="jpn"),
+            AudioTrack(media_file_id=mf.id, track_index=2, language=None, language_raw="und"),
+        ])
+        await db.commit()
+        mf = (await db.execute(select(MediaFile).options(selectinload(MediaFile.audio_tracks), selectinload(MediaFile.show)))).scalar_one()
+        yield db, user, mf, source
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("problem", [{"error": "probe failed"}, {"warning": "analysis unavailable"}])
+async def test_failed_refresh_preserves_all_previous_metadata(scanned_file, problem):
+    db, user, mf, source = scanned_file
+    before = (mf.last_scanned, mf.container_format, mf.duration_ms, mf.has_issues)
+    with patch.object(media.AudioAnalyzer, "analyze", return_value={"audio_tracks": [], **problem}):
+        with pytest.raises(HTTPException) as exc:
+            await media._refresh_media_file_analysis(db, mf, user)
+    assert exc.value.status_code == 409
+    await db.refresh(mf, attribute_names=["audio_tracks"])
+    assert [track.language for track in mf.audio_tracks] == ["en", "ja", None]
+    assert (mf.last_scanned, mf.container_format, mf.duration_ms, mf.has_issues) == before
+
+
+@pytest.mark.asyncio
+async def test_background_scan_reports_failed_probe_without_overwriting(scanned_file):
+    db, user, mf, source = scanned_file
+    source.write_bytes(source.read_bytes() + b"changed")
+    scanner = MediaScanner()
+    await scan_state_manager.reset()
+    with patch.object(scanner.analyzer, "analyze", return_value={"audio_tracks": [], "error": "probe failed"}):
+        assert await scanner.process_file(str(source), str(source.parent), "movie", user.id, db) is None
+    assert "probe failed" in (await scan_state_manager.get_status(user.id)).errors[0]
+    await db.refresh(mf, attribute_names=["audio_tracks"])
+    assert len(mf.audio_tracks) == 3
+    await scan_state_manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_successful_refresh_updates_file_size_and_modified_time(scanned_file):
+    db, user, mf, source = scanned_file
+    source.write_bytes(b"changed contents")
+    with patch.object(media.AudioAnalyzer, "analyze", return_value={"audio_tracks": [], "container": "Matroska"}):
+        await media._refresh_media_file_analysis(db, mf, user)
+    assert mf.file_size == source.stat().st_size
+    assert mf.last_modified == datetime.fromtimestamp(source.stat().st_mtime)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("languages,indices", [(["ja"], [1]), (["en", "und"], [0, 2]), (["jpn", "eng"], [0, 1])])
+async def test_removal_plan_uses_saved_languages(scanned_file, languages, indices):
+    import json
+    db, user, mf, _ = scanned_file
+    db.add(UserPreference(user_id=user.id, key="audio_preferences", value=json.dumps({"audio_track_keep_languages": languages})))
+    await db.flush()
+    plan = await media.plan_media_file_audio_tracks(mf.id, user, db)
+    assert plan.keep_track_indices == indices
+    assert plan.last_scanned == mf.last_scanned
+    other = User(id=999, plex_user_id="456", plex_username="other", plex_token="test")
+    with pytest.raises(HTTPException) as exc:
+        await media.plan_media_file_audio_tracks(mf.id, other, db)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_disabled_writes_are_enforced_on_api(scanned_file, monkeypatch):
+    db, user, mf, _ = scanned_file
+    monkeypatch.setattr(get_settings(), "media_writes_enabled", False)
+    with patch.object(media, "remove_unwanted_audio_tracks") as remove:
+        with pytest.raises(HTTPException) as exc:
+            await media.remove_media_file_audio_tracks(mf.id, AudioTrackRemovalRequest(keep_languages=["en"]), user, db)
+    assert exc.value.status_code == 403
+    remove.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_changed_file_and_stale_selection_cannot_be_edited(scanned_file, monkeypatch):
+    db, user, mf, source = scanned_file
+    monkeypatch.setattr(get_settings(), "media_writes_enabled", True)
+    monkeypatch.setattr(media_access, "MEDIA_ROOT", source.parent)
+    monkeypatch.setattr(media_access.shutil, "which", lambda _: "/tool")
+    with patch.object(media, "remove_unwanted_audio_tracks") as remove:
+        with pytest.raises(HTTPException) as exc:
+            await media.remove_media_file_audio_tracks(mf.id, AudioTrackRemovalRequest(keep_track_indices=[0], expected_last_scanned=datetime(2000, 1, 1)), user, db)
+        assert exc.value.status_code == 409
+        source.write_bytes(b"replaced")
+        with pytest.raises(HTTPException) as exc:
+            await media.remove_media_file_audio_tracks(mf.id, AudioTrackRemovalRequest(keep_languages=["en"]), user, db)
+        assert exc.value.status_code == 409
+    remove.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_removal_accepts_current_selection_and_refreshes_metadata(scanned_file, monkeypatch):
+    db, user, mf, source = scanned_file
+    monkeypatch.setattr(get_settings(), "media_writes_enabled", True)
+    monkeypatch.setattr(media_access, "MEDIA_ROOT", source.parent)
+    monkeypatch.setattr(media_access.shutil, "which", lambda _: "/tool")
+    plan = await media.plan_media_file_audio_tracks(mf.id, user, db)
+
+    def remove(path, tracks, *, keep_track_indices, keep_backup):
+        assert keep_track_indices == plan.keep_track_indices == [0, 2]
+        assert keep_backup
+        source.with_suffix(".mkv.bak").write_bytes(source.read_bytes())
+        source.write_bytes(b"remuxed")
+        return AudioTrackRemovalResult([0, 2], [1], str(source.with_suffix(".mkv.bak")))
+
+    analysis = {"container": "Matroska", "audio_tracks": [
+        {"index": 0, "language": "en", "is_default": True},
+        {"index": 1, "language_raw": "und"},
+    ]}
+    with patch.object(media, "remove_unwanted_audio_tracks", side_effect=remove), patch.object(media.AudioAnalyzer, "analyze", return_value=analysis):
+        response = await media.remove_media_file_audio_tracks(
+            mf.id, AudioTrackRemovalRequest(keep_track_indices=plan.keep_track_indices, expected_last_scanned=plan.last_scanned), user, db
+        )
+    assert response.removed_track_indices == [1]
+    assert [track.language for track in response.media_file.audio_tracks] == ["en", None]
+    assert response.media_file.file_size == len(b"remuxed")
+    assert response.media_file.last_scanned.replace(tzinfo=None) > plan.last_scanned.replace(tzinfo=None)
+    await db.commit()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["default", "remove"])
+async def test_post_edit_analysis_failure_explains_that_media_was_changed(scanned_file, monkeypatch, operation):
+    db, user, mf, source = scanned_file
+    monkeypatch.setattr(get_settings(), "media_writes_enabled", True)
+    monkeypatch.setattr(media_access, "MEDIA_ROOT", source.parent)
+    monkeypatch.setattr(media_access.shutil, "which", lambda _: "/tool")
+    backup = str(source.with_suffix(".mkv.bak"))
+    with (
+        patch.object(media, "set_default_track_by_language", return_value=True),
+        patch.object(media, "remove_unwanted_audio_tracks", return_value=AudioTrackRemovalResult([0], [1, 2], backup)),
+        patch.object(media.AudioAnalyzer, "analyze", return_value={"audio_tracks": [], "error": "probe failed"}),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            if operation == "default":
+                await media.update_media_file_default_audio(mf.id, UpdateDefaultAudioRequest(language="en"), user, db)
+            else:
+                await media.remove_media_file_audio_tracks(mf.id, AudioTrackRemovalRequest(keep_languages=["en"]), user, db)
+    assert exc.value.status_code == 409
+    assert ("Default audio was updated" if operation == "default" else "Audio tracks were removed") in exc.value.detail
+    assert "Rescan before editing again" in exc.value.detail
+    if operation == "remove":
+        assert backup in exc.value.detail
+    await db.refresh(mf, attribute_names=["audio_tracks"])
+    assert len(mf.audio_tracks) == 3
+
+
+def test_edit_capabilities_reject_read_only_and_escaping_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(get_settings(), "media_writes_enabled", True)
+    monkeypatch.setattr(media_access, "MEDIA_ROOT", tmp_path / "media")
+    monkeypatch.setattr(media_access.shutil, "which", lambda _: "/tool")
+    root = tmp_path / "media"
+    root.mkdir()
+    source = root / "test.mkv"
+    source.write_bytes(b"test")
+    assert media_access.get_media_edit_capabilities(str(source)).remove_audio_tracks
+    with patch.object(media_access.os, "access", return_value=False):
+        assert not media_access.get_media_edit_capabilities(str(source)).set_default_audio
+    outside = tmp_path / "outside.mkv"
+    outside.write_bytes(b"test")
+    link = root / "link.mkv"
+    link.symlink_to(outside)
+    assert not media_access.get_media_edit_capabilities(str(link)).remove_audio_tracks
+    monkeypatch.setattr(media_access.shutil, "which", lambda _: None)
+    assert not media_access.get_media_edit_capabilities(str(source)).set_default_audio
+
+
+def test_scanner_does_not_discover_in_progress_remux_outputs(tmp_path):
+    (tmp_path / "movie.mkv").write_bytes(b"test")
+    (tmp_path / ".trackhound-temporary.mkv").write_bytes(b"test")
+    assert MediaScanner().discover_files(str(tmp_path)) == [str(tmp_path / "movie.mkv")]

--- a/backend/tests/test_mkv_integration.py
+++ b/backend/tests/test_mkv_integration.py
@@ -1,0 +1,39 @@
+"""Real MKV tools are installed by CI; local environments may skip this test."""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from app.core.analyzer import AudioAnalyzer, require_successful_analysis
+from app.core.audio_fixer import remove_unwanted_audio_tracks, set_default_track_by_language
+
+
+@pytest.mark.skipif(any(shutil.which(tool) is None for tool in ("ffmpeg", "mkvmerge", "mkvpropedit")), reason="requires ffmpeg and MKVToolNix")
+def test_real_mkv_edit_retains_video_subtitles_and_original_backup(tmp_path):
+    source = tmp_path / "fixture.mkv"
+    subtitles = tmp_path / "subtitles.srt"
+    subtitles.write_text("1\n00:00:00,000 --> 00:00:00,200\nTest subtitle\n", encoding="utf-8")
+    subprocess.run([
+        "ffmpeg", "-v", "error", "-f", "lavfi", "-i", "color=size=16x16:rate=10:duration=0.2",
+        "-f", "lavfi", "-i", "anullsrc=r=8000:cl=mono",
+        "-f", "lavfi", "-i", "anullsrc=r=8000:cl=mono", "-i", str(subtitles),
+        "-map", "0:v", "-map", "1:a", "-map", "2:a", "-map", "3:s", "-t", "0.2",
+        "-c:v", "ffv1", "-c:a", "pcm_s16le", "-c:s", "srt",
+        "-metadata:s:a:0", "language=eng", "-metadata:s:a:1", "language=jpn",
+        "-disposition:a:0", "default", "-disposition:a:1", "0", str(source),
+    ], check=True, capture_output=True, timeout=30)
+    analyzer = AudioAnalyzer()
+    tracks = require_successful_analysis(analyzer.analyze(str(source)))["audio_tracks"]
+    assert [track["language"] for track in tracks] == ["en", "ja"]
+    assert set_default_track_by_language(str(source), tracks, "ja")
+    updated = require_successful_analysis(analyzer.analyze(str(source)))["audio_tracks"]
+    assert [track["language"] for track in updated if track["is_default"]] == ["ja"]
+    original = source.read_bytes()
+    result = remove_unwanted_audio_tracks(str(source), updated, [0])
+    assert source.with_suffix(".mkv.bak").read_bytes() == original
+    assert result.removed_track_indices == [1]
+    probe = json.loads(subprocess.run(["mkvmerge", "-J", str(source)], check=True, capture_output=True, text=True, timeout=30).stdout)
+    assert [track["type"] for track in probe["tracks"]] == ["video", "audio", "subtitles"]
+    assert [track["language"] for track in analyzer.analyze(str(source))["audio_tracks"]] == ["en"]

--- a/backend/tests/test_remux_recovery.py
+++ b/backend/tests/test_remux_recovery.py
@@ -1,0 +1,123 @@
+"""Exercise remux failures using isolated files and injected filesystem errors."""
+
+from pathlib import Path
+from unittest.mock import patch
+import subprocess
+
+import pytest
+
+from app.core import audio_fixer
+
+TRACKS = [{"index": 0, "language": "en"}, {"index": 1, "language": "ja"}]
+
+
+@pytest.fixture
+def remux(tmp_path):
+    source = tmp_path / "movie.mkv"
+    source.write_bytes(b"original")
+    backup = source.with_suffix(".mkv.bak")
+
+    def probe(path):
+        return [1, 2] if Path(path) == source else [1]
+
+    def run(command, **kwargs):
+        Path(command[2]).write_bytes(b"verified remux")
+
+    with (
+        patch.object(audio_fixer, "_get_mkvmerge_audio_track_ids", side_effect=probe),
+        patch.object(audio_fixer.subprocess, "run", side_effect=run) as command,
+    ):
+        yield source, backup, command
+
+
+def test_existing_backup_is_never_overwritten(remux):
+    source, backup, command = remux
+    backup.write_bytes(b"earlier original")
+    with pytest.raises(audio_fixer.AudioTrackRemovalError, match="already exists"):
+        audio_fixer.remove_unwanted_audio_tracks(str(source), TRACKS, [0])
+    assert source.read_bytes() == b"original"
+    assert backup.read_bytes() == b"earlier original"
+    command.assert_not_called()
+
+
+def test_failed_final_rename_restores_original_path(remux, monkeypatch):
+    source, backup, _ = remux
+    replace = Path.replace
+
+    def fail_install(path, target):
+        if path.name.startswith(".trackhound-"):
+            raise OSError("injected final rename failure")
+        return replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_install)
+    with pytest.raises(audio_fixer.AudioTrackRemovalError, match="restored"):
+        audio_fixer.remove_unwanted_audio_tracks(str(source), TRACKS, [0])
+    assert source.read_bytes() == b"original"
+    assert not backup.exists()
+    assert not list(source.parent.glob(".trackhound-*.mkv"))
+
+
+def test_failed_restoration_preserves_backup_and_reports_recovery_path(remux, monkeypatch):
+    source, backup, _ = remux
+    replace = Path.replace
+
+    def fail_install_and_restore(path, target):
+        if path.name.startswith(".trackhound-") or path == backup:
+            raise OSError("injected failure")
+        return replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_install_and_restore)
+    with pytest.raises(audio_fixer.AudioTrackRemovalError, match=str(backup)):
+        audio_fixer.remove_unwanted_audio_tracks(str(source), TRACKS, [0])
+    assert backup.read_bytes() == b"original"
+    assert not source.exists()
+
+
+def test_remux_timeout_leaves_original_and_cleans_temporary_output(remux):
+    source, backup, command = remux
+    command.side_effect = subprocess.TimeoutExpired("mkvmerge", 3600)
+    with pytest.raises(audio_fixer.AudioTrackRemovalError, match="timed out"):
+        audio_fixer.remove_unwanted_audio_tracks(str(source), TRACKS, [0])
+    assert source.read_bytes() == b"original"
+    assert not backup.exists()
+    assert not list(source.parent.glob(".trackhound-*.mkv"))
+
+
+def test_invalid_remux_output_never_replaces_source(remux):
+    source, backup, _ = remux
+    with patch.object(audio_fixer, "_get_mkvmerge_audio_track_ids", return_value=[1, 2]):
+        with pytest.raises(audio_fixer.AudioTrackRemovalError, match="failed verification"):
+            audio_fixer.remove_unwanted_audio_tracks(str(source), TRACKS, [0])
+    assert source.read_bytes() == b"original"
+    assert not backup.exists()
+
+
+def test_concurrently_changed_source_is_not_replaced(remux):
+    source, backup, command = remux
+
+    def run(command, **kwargs):
+        Path(command[2]).write_bytes(b"remux result")
+        source.write_bytes(b"another process replaced the media")
+
+    command.side_effect = run
+    with pytest.raises(audio_fixer.AudioTrackRemovalError, match="changed during"):
+        audio_fixer.remove_unwanted_audio_tracks(str(source), TRACKS, [0])
+    assert source.read_bytes() == b"another process replaced the media"
+    assert not backup.exists()
+
+
+def test_concurrent_edit_is_rejected(remux):
+    source, _, command = remux
+    with audio_fixer._edit_lock:
+        with pytest.raises(audio_fixer.AudioTrackRemovalError, match="in progress"):
+            audio_fixer.remove_unwanted_audio_tracks(str(source), TRACKS, [0])
+        assert not audio_fixer.set_default_track_by_index(str(source), TRACKS, 0)
+    command.assert_not_called()
+
+
+def test_audio_count_change_requires_rescan(remux):
+    source, _, command = remux
+    with patch.object(audio_fixer, "_get_mkvmerge_audio_track_ids", return_value=[1, 2, 3]):
+        with pytest.raises(audio_fixer.AudioTrackRemovalError, match="do not match"):
+            audio_fixer.remove_unwanted_audio_tracks(str(source), TRACKS, [0])
+    command.assert_not_called()

--- a/backend/tests/test_scanner_auto_fix.py
+++ b/backend/tests/test_scanner_auto_fix.py
@@ -84,13 +84,28 @@ class MediaScannerAutoFixTests(unittest.TestCase):
 
         self.scanner.analyzer.analyze = MagicMock(return_value=refreshed_info)
 
-        with patch("app.core.scanner.set_default_track_by_index", return_value=True) as fix_mock:
+        with (
+            patch("app.core.scanner.get_media_edit_capabilities", return_value=MagicMock(set_default_audio=True)),
+            patch("app.core.scanner.set_default_track_by_index", return_value=True) as fix_mock,
+        ):
             result = self.scanner._auto_fix_default_track(
                 "/media/movies/file.mkv", audio_info, is_anime=False
             )
 
         self.assertEqual(result, refreshed_info)
         fix_mock.assert_called_once_with("/media/movies/file.mkv", audio_info["audio_tracks"], 1)
+
+    def test_auto_fix_respects_instance_write_policy(self):
+        audio_info = {"audio_tracks": [
+            {"index": 0, "language": "ja", "is_default": True},
+            {"index": 1, "language": "en", "is_default": False},
+        ]}
+        with (
+            patch("app.core.scanner.get_media_edit_capabilities", return_value=MagicMock(set_default_audio=False)),
+            patch("app.core.scanner.set_default_track_by_index") as fix_mock,
+        ):
+            assert self.scanner._auto_fix_default_track("/media/file.mkv", audio_info, False) is audio_info
+        fix_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   trackhound:
     build: .
@@ -11,11 +9,13 @@ services:
       - /mnt/user/Media/TV:/media/tv:ro
       - /mnt/user/Media/Anime:/media/anime:ro
     environment:
-      - SECRET_KEY=${SECRET_KEY:?SECRET_KEY must be set — generate with: openssl rand -hex 32}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set — generate with: openssl rand -base64 32}
+      - SECRET_KEY=${SECRET_KEY:?Set SECRET_KEY in .env}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env}
       - DATABASE_URL=postgresql+asyncpg://trackhound:${POSTGRES_PASSWORD:-trackhound}@db:5432/trackhound
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:8080}
       - ENVIRONMENT=production
+      - ALLOWED_PLEX_USER_IDS=${ALLOWED_PLEX_USER_IDS:-}
+      - MEDIA_WRITES_ENABLED=${MEDIA_WRITES_ENABLED:-false}
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,6 @@ services:
       - DATABASE_URL=sqlite+aiosqlite:///./data/trackhound.db
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:8383}
       - ENVIRONMENT=production
+      - ALLOWED_PLEX_USER_IDS=${ALLOWED_PLEX_USER_IDS:-}
+      - MEDIA_WRITES_ENABLED=${MEDIA_WRITES_ENABLED:-false}
     restart: unless-stopped

--- a/docs/IMPLEMENTATION_PROGRESS.md
+++ b/docs/IMPLEMENTATION_PROGRESS.md
@@ -3,6 +3,9 @@
 Branch: `fix/secure-media-editing`  
 Review baseline: `0ce4fa81fd8adc264fbf5b78457ad097939a91e2` on `master`
 
+Draft review: [PR #42](https://github.com/TheSoloGreen/TrackHound/pull/42).
+Implementation is committed and saved on the branch; `master` is unchanged.
+
 ## Project overview
 
 TrackHound scans mounted media files with MediaInfo, stores per-user shows,
@@ -43,6 +46,11 @@ No database migration, image deployment, or merge to `master` is part of this ba
 - Original baseline: 38 backend tests passed; frontend production build passed.
 - Updated local suite: 80 passed, 1 skipped. The skipped test needs native
   MKVToolNix executables, which are unavailable in the editing environment.
+- [CI run 34216958766](https://github.com/TheSoloGreen/TrackHound/actions/runs/34216958766)
+  passed on implementation commit `f6a8c1803f1c2e65de481d5b62513cca6872e134`:
+  **81 backend tests passed**, including the real MKV test. Frontend build and
+  container/Compose validation, secure startup, tool checks, and health smoke test
+  all passed. Image publication was correctly skipped for the draft PR.
 - Frontend: `npm run build` passed (TypeScript and Vite).
 - CI now installs ffmpeg, MediaInfo, and MKVToolNix for a real generated MKV test
   that verifies language selection, default flags, video/subtitle retention, and

--- a/docs/IMPLEMENTATION_PROGRESS.md
+++ b/docs/IMPLEMENTATION_PROGRESS.md
@@ -1,0 +1,76 @@
+# TrackHound implementation checkpoint
+
+Branch: `fix/secure-media-editing`  
+Review baseline: `0ce4fa81fd8adc264fbf5b78457ad097939a91e2` on `master`
+
+## Project overview
+
+TrackHound scans mounted media files with MediaInfo, stores per-user shows,
+seasons, audio tracks, and preference violations in SQLite or PostgreSQL, and
+uses Plex for sign-in and metadata enrichment. Its React/TypeScript interface
+supports filtering, exports, rescans, default-audio changes, and MKV track removal.
+The application is packaged as a single FastAPI container serving the frontend.
+
+## First implementation batch
+
+- Restrict Plex login and existing sessions to an administrator-configured account
+  allowlist. Blank configuration denies access. Reject known default and short
+  production keys, including direct use of the published image. Addresses #40.
+- Ship MKVToolNix and make all media writes an explicit instance opt-in. Report
+  live per-file tool, mount, and permission capabilities in the API and UI.
+  Apply the same policy to scan-time automatic edits. Addresses #28.
+- Fix PostgreSQL Compose environment strings and validate both deployment files
+  in CI. Addresses #26.
+- Use the saved keep-language policy for the UI's initial pruning selection.
+  Require the scan revision for explicit track indices and reject changed files.
+  Show the kept and removed tracks in confirmation. Addresses #35.
+- Preserve existing audio metadata on failed or unavailable analysis. Show scan
+  errors and refresh related cached file/show/stat data after file actions.
+  These are partial improvements for #38.
+- Serialize in-process edits, bound native subprocess durations, verify remux
+  output and source stability, protect prior backups, and restore the original
+  after replacement failures. Keep scan discovery away from temporary remux files.
+- Run manual editing and analysis off the request event loop. Broader scan worker
+  changes remain outstanding.
+- Add deployment, key, database-backup, and media-recovery notes in
+  [OPERATIONS.md](OPERATIONS.md), contributing to #41. Automated restore rehearsal
+  and key-rotation tooling remain future work.
+
+No database migration, image deployment, or merge to `master` is part of this batch.
+
+## Validation
+
+- Original baseline: 38 backend tests passed; frontend production build passed.
+- Updated local suite: 80 passed, 1 skipped. The skipped test needs native
+  MKVToolNix executables, which are unavailable in the editing environment.
+- Frontend: `npm run build` passed (TypeScript and Vite).
+- CI now installs ffmpeg, MediaInfo, and MKVToolNix for a real generated MKV test
+  that verifies language selection, default flags, video/subtitle retention, and
+  byte-for-byte preservation of the original backup.
+- CI also validates both Compose files, builds the production image, rejects
+  insecure direct image configuration, checks editing tools and read-only defaults,
+  and smoke-tests startup and health. Image publishing depends on these checks.
+- Local regression tests cover unauthorized Plex accounts and revoked sessions,
+  stale track choices, read-only paths, symlink escapes, saved language policies,
+  failed probes, successful API metadata refresh, concurrent edits, remux timeout,
+  existing backups, failed replacement, and failed automatic restoration.
+
+Run from `backend`: `python -m pytest -q`. Run from `frontend`: `npm ci && npm run build`.
+Consult the PR checks for native-tool and container results; those cannot run in
+the local editing environment.
+
+## Remaining work, in suggested order
+
+| Area | Work and existing issue |
+| --- | --- |
+| Database correctness | Introduce versioned migrations and upgrade tests (#27); scope file-path uniqueness per user and recover failed scan transactions (#33); enable and verify SQLite foreign keys (#39). |
+| Scan correctness | Honor full vs incremental scans (#29), saved extension/anime settings (#30), and reconcile deleted files only after successful discovery (#31). |
+| Scan resilience | Make Plex failures degrade to local metadata (#32); move synchronous scan probes, Plex calls, and filesystem work out of the async request loop; use durable job state and shared edit coordination before adding workers. |
+| Settings | Replace saves on every keystroke with a draft and explicit save or serialized partial updates (#34). |
+| Classification | Apply manual anime overrides consistently, including before scan-time auto-fixes (#37). |
+| Frontend consistency | Finish scan-completion cache invalidation and durable error reporting (#38); add SPA fallback for direct navigation to nested routes (#36). |
+| Operations | Rehearse database restore and build controlled key rotation (#41); document tested upgrade paths and pin release dependencies. |
+
+Existing issues are at `https://github.com/TheSoloGreen/TrackHound/issues/<number>`.
+When resuming, inspect the branch and PR checks first, preserve completed work,
+then select the next bounded batch from this table.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,90 @@
+# Deployment, upgrades, and recovery
+
+## Before upgrading an existing installation
+
+1. Stop TrackHound so scans and media edits have finished, then record the current
+   image tag or digest for a possible rollback.
+2. Back up the database and deployment configuration, including both keys. For
+   SQLite, copy the entire stopped container's persisted `/app/data` directory,
+   including any SQLite journal files. For PostgreSQL, take a database backup
+   with `pg_dump` and retain the database credentials. Store keys securely, with
+   access limited to the administrator; do not commit `.env` or backups to Git.
+3. Keep existing non-default `SECRET_KEY` and `ENCRYPTION_KEY` values if each is
+   at least 32 characters. The production image now rejects weaker values.
+4. Configure `ALLOWED_PLEX_USER_IDS`. If the ID is unknown, the Plex login denial
+   shows the account ID after Plex verifies that account. Add the ID and recreate
+   the container. An empty list deliberately grants no access, and removing an
+   account also blocks its existing sessions after restart.
+5. Keep `MEDIA_WRITES_ENABLED=false` while verifying startup, sign-in, and scans.
+   Explicitly enable writes and writable media mounts only for libraries you
+   intend TrackHound to edit.
+
+This change adds no database columns. Existing migration behavior is unchanged;
+versioned database migrations remain a separate follow-up.
+
+## Keys and Plex reconnection
+
+`SECRET_KEY` signs browser sessions. Changing it requires users to sign in again.
+`ENCRYPTION_KEY` decrypts stored Plex tokens. Changing or losing it makes previously
+encrypted tokens unreadable; this update does not rotate or re-encrypt those tokens.
+Restore the matching key with a database backup. If an insecure key must be
+replaced, preserve the old database and key securely first, generate a new key,
+and have each approved user sign in again to replace their stored Plex token.
+Verify their Plex connection before starting another scan.
+
+The allowlist applies equally to development and production. All approved users
+can use the instance's mounted media, subject to its filesystem permissions and
+write policy. It is an instance access restriction, not a per-library permissions
+system.
+
+## Media edits and recovery
+
+Track removal writes a unique temporary MKV next to the source. TrackHound checks
+that the output is nonempty and has the expected audio-track count, checks whether
+the source changed during remuxing, then replaces the source. The UI always asks
+for a backup; the API's `keep_backup` also defaults to `true`. API callers that
+explicitly disable it forgo that recovery copy.
+
+The original is kept as `<filename>.mkv.bak`. An existing backup is never
+intentionally overwritten. Move a prior backup to secure storage before a later
+edit. Normal replacement errors trigger automatic restoration; if restoration
+also fails, the error reports the backup's recovery path. A failed analysis after
+an edit reports that the media changed while retaining the previous database
+analysis. Rescan the file before another edit.
+
+To restore a media backup:
+
+1. Stop TrackHound and any other process writing the media file.
+2. Verify the reported `.bak` file exists and contains the expected media. Preserve
+   the current edited file under a different name before replacing anything.
+3. Restore the backup to the original filename with the original permissions.
+4. Restart TrackHound and rescan the file. Check playback, audio selection, and
+   subtitles before discarding either copy.
+
+Default-audio edits use `mkvpropedit` in place and do not create a `.bak` file.
+Keep a separate library backup if those changes need to be reversible. A timeout
+or process termination during an in-place edit can require inspection and rescan.
+
+Use the default **one application worker and one container per media library**.
+The edit lock serializes operations within one process; it does not coordinate
+multiple containers, workers, or outside media tools. Do not modify a file with
+other software during an edit. Remuxing has a one-hour timeout; file inspection
+and default-audio editing have 30-second and 60-second subprocess timeouts.
+
+The database and filesystem do not share an atomic transaction. A machine crash
+between replacement steps may leave the original at its `.bak` path. Filesystem
+errors, insufficient disk space, and interrupted in-place edits still require
+operator recovery. Do not treat a `.bak` file as a substitute for a separate backup.
+
+## Restoring the application
+
+Stop TrackHound before restoring its data. Restore the SQLite data directory or
+the PostgreSQL dump together with the matching deployment configuration and
+encryption key. Restore ownership so the container's UID/GID `1000:1000` can read
+and write its data. Start with media writes disabled, check `/api/health`, sign in
+with an approved Plex account, and verify saved locations and a sample file scan.
+Application database backups do not contain your media files; restore those
+separately when needed.
+
+If rolling back an image after future schema changes, use the backup associated
+with that image rather than assuming an older version understands a newer schema.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -56,6 +56,7 @@ export const scanApi = {
 
 // Media API
 export const mediaApi = {
+  getCapabilities: () => api.get('/api/media/capabilities'),
   getStats: () => api.get('/api/media/stats'),
   getShows: (params?: { page?: number; page_size?: number; media_type?: string; is_anime?: boolean; has_issues?: boolean; search?: string }) =>
     api.get('/api/media/shows', { params }),
@@ -74,8 +75,9 @@ export const mediaApi = {
     api.post(`/api/media/files/${id}/default-audio`, { language }),
   removeAudioTracks: (
     id: number,
-    data: { keep_track_indices?: number[]; keep_languages?: string[]; keep_backup?: boolean }
+    data: { keep_track_indices?: number[]; keep_languages?: string[]; keep_backup?: boolean; expected_last_scanned?: string }
   ) => api.post(`/api/media/files/${id}/audio-tracks/remove`, data),
+  getAudioTrackRemovalPlan: (id: number) => api.get(`/api/media/files/${id}/audio-tracks/plan`),
   rescanFile: (id: number) => api.post(`/api/media/files/${id}/rescan`),
   rescanShow: (id: number) => api.post(`/api/media/shows/${id}/rescan`),
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -191,6 +191,18 @@ export default function DashboardPage() {
       )}
 
       {/* Stats Grid */}
+      {!!scanStatus?.errors.length && (
+        <details className="p-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg">
+          <summary className="cursor-pointer text-sm text-red-700 dark:text-red-400">
+            {scanStatus.errors.length} scan error{scanStatus.errors.length === 1 ? '' : 's'} reported
+          </summary>
+          <ul className="mt-2 space-y-1 text-sm text-red-700 dark:text-red-400 break-words">
+            {scanStatus.errors.slice(0, 50).map((message, index) => <li key={index}>{message}</li>)}
+          </ul>
+          {scanStatus.errors.length > 50 && <p className="mt-2 text-sm text-red-700 dark:text-red-400">Showing the first 50 errors.</p>}
+        </details>
+      )}
+
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <StatCard
           icon={Layers}

--- a/frontend/src/pages/FilesPage.tsx
+++ b/frontend/src/pages/FilesPage.tsx
@@ -3,7 +3,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Search, AlertTriangle, FileVideo, ChevronDown, ChevronUp, Download, RefreshCw, Trash2 } from 'lucide-react'
 import { mediaApi } from '../api/client'
 import { useDebounce } from '../hooks/useDebounce'
-import type { MediaFile, PaginatedResponse } from '../types'
+import type { MediaFile, PaginatedResponse, AudioTrackRemovalPlan } from '../types'
+import { isAxiosError } from 'axios'
 
 function AudioTrackBadge({ track }: { track: MediaFile['audio_tracks'][0] }) {
   const langColors: Record<string, string> = {
@@ -29,22 +30,33 @@ export default function FilesPage() {
   const [hasIssues, setHasIssues] = useState<boolean | undefined>(undefined)
   const [issueCategory, setIssueCategory] = useState<'missing_required_audio' | 'preferred_not_default' | undefined>(undefined)
   const [expandedFile, setExpandedFile] = useState<number | null>(null)
-  const [trackKeepSelections, setTrackKeepSelections] = useState<Record<number, number[]>>({})
+  const [trackKeepSelections, setTrackKeepSelections] = useState<Record<string, number[]>>({})
   const [actionError, setActionError] = useState<string | null>(null)
   const [isResetting, setIsResetting] = useState(false)
   const queryClient = useQueryClient()
   const debouncedSearch = useDebounce(search, 300)
+
+  const refreshMedia = () => {
+    setTrackKeepSelections({})
+    return Promise.all(['files', 'stats', 'shows', 'show', 'season', 'trackRemovalPlan'].map(
+      (key) => queryClient.invalidateQueries({ queryKey: [key] })
+    ))
+  }
+
+  const showActionError = (error: unknown) => {
+    setActionError(isAxiosError(error) && typeof error.response?.data?.detail === 'string'
+      ? error.response.data.detail : 'The operation failed. Please try again.')
+    void refreshMedia()
+  }
 
   const updateDefaultAudio = useMutation({
     mutationFn: ({ fileId, language }: { fileId: number; language: string }) =>
       mediaApi.updateDefaultAudio(fileId, language),
     onSuccess: () => {
       setActionError(null)
-      queryClient.invalidateQueries({ queryKey: ['files'] })
+      return refreshMedia()
     },
-    onError: () => {
-      setActionError('Failed to update default audio track. Ensure this is an MKV file and the language exists.')
-    },
+    onError: showActionError,
   })
 
 
@@ -52,24 +64,19 @@ export default function FilesPage() {
     mutationFn: (fileId: number) => mediaApi.rescanFile(fileId),
     onSuccess: () => {
       setActionError(null)
-      queryClient.invalidateQueries({ queryKey: ['files'] })
+      return refreshMedia()
     },
-    onError: () => {
-      setActionError('Failed to rescan file. Please confirm the file still exists and try again.')
-    },
+    onError: showActionError,
   })
 
   const removeAudioTracks = useMutation({
     mutationFn: ({ file, keepTrackIndices }: { file: MediaFile; keepTrackIndices: number[] }) =>
-      mediaApi.removeAudioTracks(file.id, { keep_track_indices: keepTrackIndices, keep_backup: true }),
+      mediaApi.removeAudioTracks(file.id, { keep_track_indices: keepTrackIndices, keep_backup: true, expected_last_scanned: file.last_scanned }),
     onSuccess: () => {
       setActionError(null)
-      queryClient.invalidateQueries({ queryKey: ['files'] })
+      return refreshMedia()
     },
-    onError: (error: unknown) => {
-      const maybeAxiosError = error as { response?: { data?: { detail?: string } } }
-      setActionError(maybeAxiosError.response?.data?.detail || 'Failed to remove audio tracks. Confirm this is an MKV file and mkvmerge is installed.')
-    },
+    onError: showActionError,
   })
 
   const { data, isLoading, error } = useQuery<PaginatedResponse<MediaFile>>({
@@ -86,6 +93,12 @@ export default function FilesPage() {
     },
   })
 
+  const expandedMediaFile = data?.items.find((file) => file.id === expandedFile)
+  const { data: removalPlan, isFetching: planLoading, error: planError } = useQuery<AudioTrackRemovalPlan>({
+    queryKey: ['trackRemovalPlan', expandedFile, expandedMediaFile?.last_scanned],
+    queryFn: async () => (await mediaApi.getAudioTrackRemovalPlan(expandedFile!)).data,
+    enabled: !!expandedMediaFile,
+  })
 
 
   const handleExport = async (format: 'csv' | 'json' = 'csv') => {
@@ -146,13 +159,9 @@ export default function FilesPage() {
     return `${mb.toFixed(1)} MB`
   }
 
-  const defaultKeepTrackIndices = (file: MediaFile) =>
-    file.audio_tracks
-      .filter((track) => (track.language || track.language_raw || 'und').toLowerCase() === 'en' || (track.language_raw || '').toLowerCase() === 'und' || !track.language)
-      .map((track) => track.track_index)
-
   const selectedKeepTrackIndices = (file: MediaFile) =>
-    trackKeepSelections[file.id] ?? defaultKeepTrackIndices(file)
+    trackKeepSelections[`${file.id}:${file.last_scanned}`] ??
+      (removalPlan?.file_id === file.id && removalPlan.last_scanned === file.last_scanned ? removalPlan.keep_track_indices : [])
 
   const toggleKeepTrack = (file: MediaFile, trackIndex: number) => {
     const selected = new Set(selectedKeepTrackIndices(file))
@@ -163,11 +172,12 @@ export default function FilesPage() {
     }
     setTrackKeepSelections((prev) => ({
       ...prev,
-      [file.id]: [...selected].sort((a, b) => a - b),
+      [`${file.id}:${file.last_scanned}`]: [...selected].sort((a, b) => a - b),
     }))
   }
 
   const handleRemoveAudioTracks = (file: MediaFile) => {
+    if (planLoading || planError || !file.edit_capabilities?.remove_audio_tracks) return
     const keepTrackIndices = selectedKeepTrackIndices(file)
     const removeCount = file.audio_tracks.length - keepTrackIndices.length
     if (keepTrackIndices.length === 0) {
@@ -178,8 +188,12 @@ export default function FilesPage() {
       setActionError('Select fewer tracks to keep before removing audio tracks.')
       return
     }
+    const describe = (keep: boolean) => file.audio_tracks
+      .filter((track) => keepTrackIndices.includes(track.track_index) === keep)
+      .map((track) => `#${track.track_index} ${(track.language || track.language_raw || 'und').toUpperCase()}${track.title ? ` (${track.title})` : ''}`)
+      .join(', ')
     const confirmed = window.confirm(
-      `Remove ${removeCount} audio track${removeCount === 1 ? '' : 's'} from ${file.filename}? TrackHound will keep a .bak fallback beside the original file.`
+      `Edit ${file.filename}?\n\nKeep: ${describe(true)}\nRemove: ${describe(false)}\n\nThe original will be preserved as a .bak file. Existing backups will not be overwritten.`
     )
     if (!confirmed) return
     removeAudioTracks.mutate({ file, keepTrackIndices })
@@ -378,18 +392,25 @@ export default function FilesPage() {
                                   e.stopPropagation()
                                   updateDefaultAudio.mutate({ fileId: file.id, language: lang })
                                 }}
-                                disabled={updateDefaultAudio.isPending}
+                                disabled={updateDefaultAudio.isPending || removeAudioTracks.isPending || !file.edit_capabilities?.set_default_audio}
+                                title={file.edit_capabilities?.default_audio_reason || undefined}
                                 className="px-2.5 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
                               >
                                 {lang.toUpperCase()}
                               </button>
                             ))}
                           </div>
+                          {file.edit_capabilities?.default_audio_reason && (
+                            <p className="text-xs text-gray-500 dark:text-gray-400">{file.edit_capabilities.default_audio_reason}</p>
+                          )}
                           <div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3 space-y-3">
                             <div>
                               <span className="text-sm font-medium text-amber-800 dark:text-amber-300">Remove audio tracks:</span>
                               <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">
-                                Select the audio tracks to keep. Default selection keeps English and UND tracks.
+                                Select the tracks to keep. The initial selection uses your saved language preferences.
+                              </p>
+                              <p className="text-xs text-amber-700 dark:text-amber-400 mt-1" role="status">
+                                {file.edit_capabilities?.track_removal_reason || (planError ? 'Unable to load saved track preferences. Try reopening this file.' : planLoading ? 'Loading saved track preferences...' : '')}
                               </p>
                             </div>
                             <div className="flex flex-wrap gap-2">
@@ -403,6 +424,7 @@ export default function FilesPage() {
                                     <input
                                       type="checkbox"
                                       checked={selected}
+                                      disabled={planLoading || !!planError || removeAudioTracks.isPending || !file.edit_capabilities?.remove_audio_tracks}
                                       onChange={() => toggleKeepTrack(file, track.track_index)}
                                       className="w-3.5 h-3.5 text-orange-500 rounded"
                                     />
@@ -416,7 +438,7 @@ export default function FilesPage() {
                                 e.stopPropagation()
                                 handleRemoveAudioTracks(file)
                               }}
-                              disabled={removeAudioTracks.isPending}
+                              disabled={removeAudioTracks.isPending || updateDefaultAudio.isPending || planLoading || !!planError || removalPlan?.last_scanned !== file.last_scanned || !file.edit_capabilities?.remove_audio_tracks}
                               className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white"
                             >
                               <Trash2 className="w-3.5 h-3.5" />

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { Tv, Loader2 } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
 import { authApi } from '../api/client'
+import { isAxiosError } from 'axios'
 
 export default function LoginPage() {
   const { isAuthenticated, login } = useAuth()
@@ -48,6 +49,12 @@ export default function LoginPage() {
         navigate('/', { replace: true })
       } catch (err: unknown) {
         if (cancelledRef.current) return
+        if (isAxiosError(err) && err.response?.status === 403) {
+          setError(err.response.data?.detail || 'This Plex account is not approved for this instance.')
+          setIsLoading(false)
+          if (windowCheckRef.current) clearInterval(windowCheckRef.current)
+          return
+        }
         attempts++
         if (attempts < maxAttempts) {
           // PIN not yet authorized, keep polling

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Plus, Trash2, FolderOpen, ChevronRight, Folder } from 'lucide-react'
-import { settingsApi, scanApi } from '../api/client'
-import type { UserSettings, ScanLocation, DirectoryBrowseResponse, MediaType } from '../types'
+import { settingsApi, scanApi, mediaApi } from '../api/client'
+import type { UserSettings, ScanLocation, DirectoryBrowseResponse, MediaType, MediaEditCapabilities } from '../types'
 
 const MEDIA_TYPE_OPTIONS: { value: MediaType; label: string }[] = [
   { value: 'movie', label: 'Movies' },
@@ -126,6 +126,10 @@ function DirectoryPicker({
 
 export default function SettingsPage() {
   const queryClient = useQueryClient()
+  const { data: editCapabilities } = useQuery<MediaEditCapabilities>({
+    queryKey: ['mediaCapabilities'],
+    queryFn: async () => (await mediaApi.getCapabilities()).data,
+  })
   const [showPicker, setShowPicker] = useState(false)
   const [newLocation, setNewLocation] = useState({
     path: '',
@@ -156,6 +160,7 @@ export default function SettingsPage() {
     mutationFn: (data: Partial<UserSettings>) => settingsApi.update(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['settings'] })
+      queryClient.invalidateQueries({ queryKey: ['trackRemovalPlan'] })
     },
     onError: () => {
       queryClient.invalidateQueries({ queryKey: ['settings'] })
@@ -431,6 +436,7 @@ export default function SettingsPage() {
             <input
               type="checkbox"
               checked={settings?.audio_preferences.auto_fix_english_default_non_anime ?? false}
+              disabled={!editCapabilities?.set_default_audio}
               onChange={(e) => {
                 if (!settings) return
                 updateSettings.mutate({
@@ -447,7 +453,7 @@ export default function SettingsPage() {
                 Auto-fix default to English (non-anime)
               </span>
               <p className="text-sm text-gray-500 dark:text-gray-400">
-                Automatically set English as default during scans for non-anime files when available
+                {editCapabilities?.default_audio_reason || 'Automatically set English as default during scans for writable non-anime MKV files.'}
               </p>
             </div>
           </label>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -59,6 +59,19 @@ export interface AudioTrack {
 }
 
 // Media types
+export interface MediaEditCapabilities {
+  set_default_audio: boolean
+  remove_audio_tracks: boolean
+  default_audio_reason: string | null
+  track_removal_reason: string | null
+}
+
+export interface AudioTrackRemovalPlan {
+  file_id: number
+  last_scanned: string
+  keep_track_indices: number[]
+}
+
 export interface MediaFile {
   id: number
   file_path: string
@@ -72,6 +85,7 @@ export interface MediaFile {
   has_issues: boolean
   issue_details: string | null
   audio_tracks: AudioTrack[]
+  edit_capabilities?: MediaEditCapabilities
 }
 
 export interface Season {


### PR DESCRIPTION
TrackHound exposed file-editing actions without a reliable deployment capability check, accepted any Plex account, and could lose valid analysis or overwrite a prior backup when an edit failed. This first implementation batch addresses those access and media-safety problems.

- Restrict Plex login and existing sessions through `ALLOWED_PLEX_USER_IDS`; an empty list denies access. Enforce non-default production signing/encryption keys in the published image.
- Install MKVToolNix and require `MEDIA_WRITES_ENABLED=true` plus writable mounts/permissions. Report editing capabilities in the API and UI, including scan-time auto-fixes.
- Compute initial track selections from saved language preferences, show exact keep/remove confirmation, and require the scan revision for explicit track indices.
- Preserve prior metadata when analysis fails. Show scan errors and invalidate related cached file/show/stat data after edits and rescans.
- Serialize in-process edits, add native-tool timeouts, verify remux output and source stability, protect existing backups, and restore the original after replacement failures.
- Fix PostgreSQL Compose environment syntax and add real MKV, Compose, and production-container checks before image publishing.

Local validation: **80 backend tests passed, 1 native-tool test skipped**; TypeScript/Vite production build passed; YAML validation and `git diff --check` passed. CI installs the missing native tools to verify a generated MKV's default language, retained audio/video/subtitles, and byte-for-byte original backup. CI also builds and smoke-tests the container.

[CI run 34216958766](https://github.com/TheSoloGreen/TrackHound/actions/runs/34216958766) passed: **81 backend tests**, including the real MKV test, plus frontend build and all container/Compose checks. The final follow-up commit only records these results in the checkpoint.

**Upgrade requirements:** configure `ALLOWED_PLEX_USER_IDS` before users can access the instance. Keep existing valid `SECRET_KEY` and `ENCRYPTION_KEY` values; changing the encryption key makes old stored Plex tokens unreadable. Editing remains disabled until explicitly enabled. Use one application worker/container per media library because edit coordination is currently in-process.

Deployment and recovery instructions: [docs/OPERATIONS.md](https://github.com/TheSoloGreen/TrackHound/blob/fix/secure-media-editing/docs/OPERATIONS.md).
Completed scope and prioritized remaining work: [docs/IMPLEMENTATION_PROGRESS.md](https://github.com/TheSoloGreen/TrackHound/blob/fix/secure-media-editing/docs/IMPLEMENTATION_PROGRESS.md).

Fixes #26, fixes #28, fixes #35, fixes #40. Partially addresses #38 and #41. Database migrations, scan reconciliation/settings correctness, SPA routing, and broader worker changes remain recorded follow-ups.

This is a draft for review; it does not deploy an image or merge changes to master.