### PR TITLE
Version database upgrades, enforce ownership integrity, and verify recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,25 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 jobs:
   backend-tests:
     name: Backend tests
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: trackhound
+          POSTGRES_PASSWORD: ci-only-postgres-password
+          POSTGRES_DB: trackhound
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U trackhound"
+          --health-interval 5s --health-timeout 5s --health-retries 10
+    env:
+      TEST_POSTGRES_URL: postgresql+asyncpg://trackhound:ci-only-postgres-password@localhost:5432/trackhound
     defaults:
       run:
         working-directory: backend
@@ -31,6 +44,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg mediainfo mkvtoolnix
 
       - name: Run backend tests
+        env:
+          TEST_POSTGRES_CONTAINER: ${{ job.services.postgres.id }}
         run: python -m pytest -q
 
   frontend-build:
@@ -117,6 +132,14 @@ jobs:
         run: |
           docker compose -f docker-compose.yml config --quiet
           docker compose -f docker-compose.postgres.yml config --quiet
+          for file in docker-compose.yml docker-compose.postgres.yml; do
+            if env -u SECRET_KEY docker compose -f "$file" config --quiet; then
+              exit 1
+            fi
+            if env -u ENCRYPTION_KEY docker compose -f "$file" config --quiet; then
+              exit 1
+            fi
+          done
       - name: Build production image
         run: docker build -t trackhound:test .
       - name: Reject direct image startup with default keys

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -205,7 +205,7 @@ async def complete_plex_login(
             user.plex_email = plex_email
             user.plex_token = encrypt_value(auth_token)
             user.plex_thumb_url = plex_thumb
-            user.last_login = datetime.now(timezone.utc)
+            user.last_login = datetime.now(timezone.utc).replace(tzinfo=None)
         else:
             # Create new user
             user = User(

--- a/backend/app/api/media.py
+++ b/backend/app/api/media.py
@@ -262,7 +262,7 @@ async def _refresh_media_file_analysis(db: AsyncSession, mf: MediaFile, current_
 
     mf.container_format = refreshed_audio.get("container")
     mf.duration_ms = refreshed_audio.get("duration_ms")
-    mf.last_scanned = datetime.now(timezone.utc)
+    mf.last_scanned = datetime.now(timezone.utc).replace(tzinfo=None)
     mf.file_size = after.st_size
     mf.last_modified = datetime.fromtimestamp(after.st_mtime)
 

--- a/backend/app/backup.py
+++ b/backend/app/backup.py
@@ -1,0 +1,37 @@
+"""Create a consistent SQLite snapshot, including committed WAL contents."""
+
+import argparse
+from contextlib import closing
+import os
+from pathlib import Path
+import sqlite3
+
+
+def backup_sqlite(source: Path, destination: Path) -> None:
+    source = source.resolve(strict=True)
+    destination = destination.absolute()
+    # Exclusive creation protects previous backups; restrictive mode protects tokens.
+    descriptor = os.open(destination, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    os.close(descriptor)
+    try:
+        with closing(sqlite3.connect(source.as_uri() + "?mode=ro", uri=True)) as original:
+            with closing(sqlite3.connect(destination)) as snapshot:
+                original.backup(snapshot, pages=1024)
+                if snapshot.execute("PRAGMA integrity_check").fetchone()[0] != "ok":
+                    raise RuntimeError("SQLite backup failed its integrity check.")
+    except BaseException:
+        destination.unlink(missing_ok=True)
+        raise
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("destination", type=Path, help="New backup filename; existing files are never overwritten")
+    arguments = parser.parse_args()
+    backup_sqlite(arguments.source, arguments.destination)
+    print(f"Verified SQLite backup: {arguments.destination}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/core/scanner.py
+++ b/backend/app/core/scanner.py
@@ -187,214 +187,218 @@ class MediaScanner:
     ) -> Optional[MediaFile]:
         """Process a single media file."""
         try:
-            is_movie = media_type == "movie"
-            is_anime = media_type == "anime"
-
-            # Check if file already exists in database
-            result = await db.execute(
-                select(MediaFile).where(
-                    MediaFile.file_path == file_path,
-                    MediaFile.user_id == user_id,
-                )
-            )
-            existing = result.scalar_one_or_none()
-
-            # Get file stats
-            stat = os.stat(file_path)
-            file_mtime = datetime.fromtimestamp(stat.st_mtime)
-
-            # Skip if file hasn't changed (incremental scan)
-            if existing and existing.last_modified >= file_mtime:
-                return existing
-
-            # Analyze audio tracks
-            audio_info = require_successful_analysis(self.analyzer.analyze(file_path))
-
-            # Determine title and metadata based on media type
-            if is_movie:
-                show_title = parse_movie_title(file_path, base_path)
-                show_info = {"show": show_title, "season": None, "episode": None}
-            else:
-                show_info = parse_show_info(file_path, base_path)
-                show_title = show_info.get("show")
-
-            # Try to get metadata from Plex first
-            plex_metadata = None
-            if self.plex_connector:
-                plex_metadata = self.plex_connector.sync_show_metadata(
-                    file_path=file_path,
-                    title_from_path=show_title,
-                )
-
-            # Determine final title and anime status
-            if plex_metadata:
-                show_title = plex_metadata["title"]
-                plex_is_anime = plex_metadata["is_anime"]
-                anime_source = "plex_genre" if plex_is_anime else None
-                plex_rating_key = plex_metadata.get("plex_rating_key")
-                thumb_url = plex_metadata.get("thumb_url")
-                # If Plex says it's anime and we're in a TV folder, upgrade to anime
-                if plex_is_anime and media_type == "tv":
-                    is_anime = True
-            else:
-                anime_source = "folder" if is_anime else None
-                plex_rating_key = None
-                thumb_url = None
-
-            # Automatically fix default audio for non-anime content when possible
-            audio_info = require_successful_analysis(
-                self._auto_fix_default_track(
-                    file_path=file_path, audio_info=audio_info, is_anime=is_anime,
-                )
-            )
-
-            # Find or create show
-            show = None
-            season = None
-
-            if show_title:
-                # First try to find by Plex rating key
-                if plex_rating_key:
-                    result = await db.execute(
-                        select(Show).where(
-                            Show.plex_rating_key == plex_rating_key,
-                            Show.user_id == user_id,
-                        )
-                    )
-                    show = result.scalar_one_or_none()
-
-                # Then try by title
-                if not show:
-                    result = await db.execute(
-                        select(Show).where(
-                            Show.title == show_title, Show.user_id == user_id
-                        )
-                    )
-                    show = result.scalar_one_or_none()
-
-                # Check path-based title (handles English folder names)
-                if (
-                    not show
-                    and show_info.get("show")
-                    and show_info["show"] != show_title
-                ):
-                    result = await db.execute(
-                        select(Show).where(
-                            Show.title == show_info["show"], Show.user_id == user_id
-                        )
-                    )
-                    existing_show = result.scalar_one_or_none()
-                    if existing_show:
-                        show = existing_show
-                        if plex_metadata:
-                            show.title = show_title
-                            show.plex_rating_key = plex_rating_key
-                            show.is_anime = is_anime
-                            show.anime_source = anime_source
-                            show.thumb_url = thumb_url
-
-                if not show:
-                    show = Show(
-                        user_id=user_id,
-                        title=show_title,
-                        media_type=media_type,
-                        plex_rating_key=plex_rating_key,
-                        is_anime=is_anime,
-                        anime_source=anime_source,
-                        thumb_url=thumb_url,
-                    )
-                    db.add(show)
-                    await db.flush()
-                elif plex_metadata and not show.plex_rating_key:
-                    show.plex_rating_key = plex_rating_key
-                    show.is_anime = is_anime
-                    show.anime_source = anime_source
-                    if thumb_url:
-                        show.thumb_url = thumb_url
-
-                # Find or create season (TV/anime only)
-                if not is_movie and show_info.get("season"):
-                    result = await db.execute(
-                        select(Season).where(
-                            Season.show_id == show.id,
-                            Season.season_number == show_info["season"],
-                        )
-                    )
-                    season = result.scalar_one_or_none()
-
-                    if not season:
-                        season = Season(
-                            show_id=show.id,
-                            season_number=show_info["season"],
-                        )
-                        db.add(season)
-                        await db.flush()
-
-            # Create or update media file
-            if existing:
-                media_file = existing
-                from app.models.entities import AudioTrack
-                from sqlalchemy import delete
-
-                await db.execute(
-                    delete(AudioTrack).where(AudioTrack.media_file_id == media_file.id)
-                )
-            else:
-                media_file = MediaFile(user_id=user_id, file_path=file_path)
-                db.add(media_file)
-
-            # Update media file info
-            media_file.filename = os.path.basename(file_path)
-            media_file.show_id = show.id if show else None
-            media_file.season_id = season.id if season else None
-            media_file.episode_number = (
-                show_info.get("episode") if not is_movie else None
-            )
-            media_file.file_size = stat.st_size
-            media_file.container_format = audio_info.get("container")
-            media_file.duration_ms = audio_info.get("duration_ms")
-            media_file.last_scanned = datetime.now(timezone.utc)
-            media_file.last_modified = file_mtime
-
-            await db.flush()
-
-            # Add audio tracks
-            from app.models.entities import AudioTrack
-
-            for track_info in audio_info.get("audio_tracks", []):
-                track = AudioTrack(
-                    media_file_id=media_file.id,
-                    track_index=track_info.get("index", 0),
-                    language=track_info.get("language"),
-                    language_raw=track_info.get("language_raw"),
-                    codec=track_info.get("codec"),
-                    channels=track_info.get("channels"),
-                    channel_layout=track_info.get("channel_layout"),
-                    bitrate=track_info.get("bitrate"),
-                    is_default=track_info.get("is_default", False),
-                    is_forced=track_info.get("is_forced", False),
-                    title=track_info.get("title"),
-                )
-                db.add(track)
-
-            await db.flush()
-
-            # Evaluate preferences and set issues
-            final_is_anime = show.is_anime if show else is_anime
-            issues = self.preference_engine.evaluate(
-                audio_info.get("audio_tracks", []),
-                is_anime=final_is_anime,
-            )
-
-            media_file.has_issues = len(issues) > 0
-            media_file.issue_details = "; ".join(issues) if issues else None
-
-            return media_file
-
+            async with db.begin_nested():
+                return await self._process_file(file_path, base_path, media_type, user_id, db)
         except Exception as e:
             logger.error("Error processing file %s: %s", file_path, e)
             await scan_state_manager.append_error(user_id, f"{file_path}: {str(e)}")
             return None
+
+    async def _process_file(self, file_path, base_path, media_type, user_id, db):
+        is_movie = media_type == "movie"
+        is_anime = media_type == "anime"
+
+        # Check if file already exists in database
+        result = await db.execute(
+            select(MediaFile).where(
+                MediaFile.file_path == file_path,
+                MediaFile.user_id == user_id,
+            )
+        )
+        existing = result.scalar_one_or_none()
+
+        # Get file stats
+        stat = os.stat(file_path)
+        file_mtime = datetime.fromtimestamp(stat.st_mtime)
+
+        # Skip if file hasn't changed (incremental scan)
+        if existing and existing.last_modified >= file_mtime:
+            return existing
+
+        # Analyze audio tracks
+        audio_info = require_successful_analysis(self.analyzer.analyze(file_path))
+
+        # Determine title and metadata based on media type
+        if is_movie:
+            show_title = parse_movie_title(file_path, base_path)
+            show_info = {"show": show_title, "season": None, "episode": None}
+        else:
+            show_info = parse_show_info(file_path, base_path)
+            show_title = show_info.get("show")
+
+        # Try to get metadata from Plex first
+        plex_metadata = None
+        if self.plex_connector:
+            plex_metadata = self.plex_connector.sync_show_metadata(
+                file_path=file_path,
+                title_from_path=show_title,
+            )
+
+        # Determine final title and anime status
+        if plex_metadata:
+            show_title = plex_metadata["title"]
+            plex_is_anime = plex_metadata["is_anime"]
+            anime_source = "plex_genre" if plex_is_anime else None
+            plex_rating_key = plex_metadata.get("plex_rating_key")
+            thumb_url = plex_metadata.get("thumb_url")
+            # If Plex says it's anime and we're in a TV folder, upgrade to anime
+            if plex_is_anime and media_type == "tv":
+                is_anime = True
+        else:
+            anime_source = "folder" if is_anime else None
+            plex_rating_key = None
+            thumb_url = None
+
+        # Automatically fix default audio for non-anime content when possible
+        audio_info = require_successful_analysis(
+            self._auto_fix_default_track(
+                file_path=file_path, audio_info=audio_info, is_anime=is_anime,
+            )
+        )
+
+        # Find or create show
+        show = None
+        season = None
+
+        if show_title:
+            # First try to find by Plex rating key
+            if plex_rating_key:
+                result = await db.execute(
+                    select(Show).where(
+                        Show.plex_rating_key == plex_rating_key,
+                        Show.user_id == user_id,
+                    )
+                )
+                show = result.scalar_one_or_none()
+
+            # Then try by title
+            if not show:
+                result = await db.execute(
+                    select(Show).where(
+                        Show.title == show_title, Show.user_id == user_id
+                    )
+                )
+                show = result.scalar_one_or_none()
+
+            # Check path-based title (handles English folder names)
+            if (
+                not show
+                and show_info.get("show")
+                and show_info["show"] != show_title
+            ):
+                result = await db.execute(
+                    select(Show).where(
+                        Show.title == show_info["show"], Show.user_id == user_id
+                    )
+                )
+                existing_show = result.scalar_one_or_none()
+                if existing_show:
+                    show = existing_show
+                    if plex_metadata:
+                        show.title = show_title
+                        show.plex_rating_key = plex_rating_key
+                        show.is_anime = is_anime
+                        show.anime_source = anime_source
+                        show.thumb_url = thumb_url
+
+            if not show:
+                show = Show(
+                    user_id=user_id,
+                    title=show_title,
+                    media_type=media_type,
+                    plex_rating_key=plex_rating_key,
+                    is_anime=is_anime,
+                    anime_source=anime_source,
+                    thumb_url=thumb_url,
+                )
+                db.add(show)
+                await db.flush()
+            elif plex_metadata and not show.plex_rating_key:
+                show.plex_rating_key = plex_rating_key
+                show.is_anime = is_anime
+                show.anime_source = anime_source
+                if thumb_url:
+                    show.thumb_url = thumb_url
+
+            # Find or create season (TV/anime only)
+            if not is_movie and show_info.get("season"):
+                result = await db.execute(
+                    select(Season).where(
+                        Season.show_id == show.id,
+                        Season.season_number == show_info["season"],
+                    )
+                )
+                season = result.scalar_one_or_none()
+
+                if not season:
+                    season = Season(
+                        show_id=show.id,
+                        season_number=show_info["season"],
+                    )
+                    db.add(season)
+                    await db.flush()
+
+        # Create or update media file
+        if existing:
+            media_file = existing
+            from app.models.entities import AudioTrack
+            from sqlalchemy import delete
+
+            await db.execute(
+                delete(AudioTrack).where(AudioTrack.media_file_id == media_file.id)
+            )
+        else:
+            media_file = MediaFile(user_id=user_id, file_path=file_path)
+            db.add(media_file)
+
+        # Update media file info
+        media_file.filename = os.path.basename(file_path)
+        media_file.show_id = show.id if show else None
+        media_file.season_id = season.id if season else None
+        media_file.episode_number = (
+            show_info.get("episode") if not is_movie else None
+        )
+        media_file.file_size = stat.st_size
+        media_file.container_format = audio_info.get("container")
+        media_file.duration_ms = audio_info.get("duration_ms")
+        media_file.last_scanned = datetime.now(timezone.utc)
+        media_file.last_modified = file_mtime
+
+        await db.flush()
+
+        # Add audio tracks
+        from app.models.entities import AudioTrack
+
+        for track_info in audio_info.get("audio_tracks", []):
+            track = AudioTrack(
+                media_file_id=media_file.id,
+                track_index=track_info.get("index", 0),
+                language=track_info.get("language"),
+                language_raw=track_info.get("language_raw"),
+                codec=track_info.get("codec"),
+                channels=track_info.get("channels"),
+                channel_layout=track_info.get("channel_layout"),
+                bitrate=track_info.get("bitrate"),
+                is_default=track_info.get("is_default", False),
+                is_forced=track_info.get("is_forced", False),
+                title=track_info.get("title"),
+            )
+            db.add(track)
+
+        await db.flush()
+
+        # Evaluate preferences and set issues
+        final_is_anime = show.is_anime if show else is_anime
+        issues = self.preference_engine.evaluate(
+            audio_info.get("audio_tracks", []),
+            is_anime=final_is_anime,
+        )
+
+        media_file.has_issues = len(issues) > 0
+        media_file.issue_details = "; ".join(issues) if issues else None
+
+        return media_file
+
 
 
 async def _load_user_audio_preferences(db: AsyncSession, user_id: int) -> AudioPreferences:

--- a/backend/app/core/scanner.py
+++ b/backend/app/core/scanner.py
@@ -361,7 +361,7 @@ class MediaScanner:
         media_file.file_size = stat.st_size
         media_file.container_format = audio_info.get("container")
         media_file.duration_ms = audio_info.get("duration_ms")
-        media_file.last_scanned = datetime.now(timezone.utc)
+        media_file.last_scanned = datetime.now(timezone.utc).replace(tzinfo=None)
         media_file.last_modified = file_mtime
 
         await db.flush()
@@ -503,7 +503,7 @@ async def run_scan(
                 )
                 scan_loc = result.scalar_one_or_none()
                 if scan_loc:
-                    scan_loc.last_scanned = datetime.now(timezone.utc)
+                    scan_loc.last_scanned = datetime.now(timezone.utc).replace(tzinfo=None)
                     file_count = (
                         await db.scalar(
                             select(func.count(MediaFile.id)).where(

--- a/backend/app/migrations/env.py
+++ b/backend/app/migrations/env.py
@@ -1,0 +1,8 @@
+"""Run migrations on the caller's existing, explicitly managed transaction."""
+
+from alembic import context
+
+connection = context.config.attributes["connection"]
+context.configure(connection=connection, transactional_ddl=True)
+with context.begin_transaction():
+    context.run_migrations()

--- a/backend/app/migrations/schema_v1.py
+++ b/backend/app/migrations/schema_v1.py
@@ -1,0 +1,90 @@
+"""Frozen schema for unversioned releases through September 2026. Do not edit."""
+
+import sqlalchemy as sa
+
+metadata = sa.MetaData()
+
+sa.Table('users', metadata,
+    sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+    sa.Column('plex_user_id', sa.String(255), nullable=False, unique=True),
+    sa.Column('plex_username', sa.String(255), nullable=False),
+    sa.Column('plex_email', sa.String(255), nullable=True),
+    sa.Column('plex_token', sa.Text(), nullable=False),
+    sa.Column('plex_thumb_url', sa.String(512), nullable=True),
+    sa.Column('created_at', sa.DateTime(), nullable=False),
+    sa.Column('last_login', sa.DateTime(), nullable=False),
+)
+
+sa.Table('scan_locations', metadata,
+    sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+    sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+    sa.Column('path', sa.String(1024), nullable=False),
+    sa.Column('label', sa.String(255), nullable=False),
+    sa.Column('media_type', sa.String(20), nullable=False),
+    sa.Column('enabled', sa.Boolean(), nullable=False),
+    sa.Column('last_scanned', sa.DateTime(), nullable=True),
+    sa.Column('file_count', sa.Integer(), nullable=False),
+    sa.Column('created_at', sa.DateTime(), nullable=False),
+)
+
+sa.Table('shows', metadata,
+    sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+    sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+    sa.Column('title', sa.String(512), nullable=False),
+    sa.Column('media_type', sa.String(20), nullable=False),
+    sa.Column('plex_key', sa.String(255), nullable=True),
+    sa.Column('plex_rating_key', sa.String(255), nullable=True),
+    sa.Column('is_anime', sa.Boolean(), nullable=False),
+    sa.Column('anime_source', sa.String(50), nullable=True),
+    sa.Column('thumb_url', sa.String(512), nullable=True),
+    sa.Column('created_at', sa.DateTime(), nullable=False),
+    sa.Column('updated_at', sa.DateTime(), nullable=False),
+)
+
+sa.Table('user_preferences', metadata,
+    sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+    sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+    sa.Column('key', sa.String(255), nullable=False),
+    sa.Column('value', sa.Text(), nullable=False),
+)
+
+sa.Table('seasons', metadata,
+    sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+    sa.Column('show_id', sa.Integer(), sa.ForeignKey('shows.id', ondelete='CASCADE'), nullable=False),
+    sa.Column('season_number', sa.Integer(), nullable=False),
+    sa.Column('plex_key', sa.String(255), nullable=True),
+    sa.Column('plex_rating_key', sa.String(255), nullable=True),
+)
+
+sa.Table('media_files', metadata,
+    sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+    sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+    sa.Column('show_id', sa.Integer(), sa.ForeignKey('shows.id', ondelete='SET NULL'), nullable=True),
+    sa.Column('season_id', sa.Integer(), sa.ForeignKey('seasons.id', ondelete='SET NULL'), nullable=True),
+    sa.Column('file_path', sa.String(1024), nullable=False, unique=True),
+    sa.Column('filename', sa.String(512), nullable=False),
+    sa.Column('episode_number', sa.Integer(), nullable=True),
+    sa.Column('episode_title', sa.String(512), nullable=True),
+    sa.Column('file_size', sa.BigInteger(), nullable=False),
+    sa.Column('container_format', sa.String(50), nullable=True),
+    sa.Column('duration_ms', sa.BigInteger(), nullable=True),
+    sa.Column('last_scanned', sa.DateTime(), nullable=False),
+    sa.Column('last_modified', sa.DateTime(), nullable=False),
+    sa.Column('has_issues', sa.Boolean(), nullable=False),
+    sa.Column('issue_details', sa.Text(), nullable=True),
+)
+
+sa.Table('audio_tracks', metadata,
+    sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+    sa.Column('media_file_id', sa.Integer(), sa.ForeignKey('media_files.id', ondelete='CASCADE'), nullable=False),
+    sa.Column('track_index', sa.Integer(), nullable=False),
+    sa.Column('language', sa.String(50), nullable=True),
+    sa.Column('language_raw', sa.String(100), nullable=True),
+    sa.Column('codec', sa.String(50), nullable=True),
+    sa.Column('channels', sa.Integer(), nullable=True),
+    sa.Column('channel_layout', sa.String(50), nullable=True),
+    sa.Column('bitrate', sa.Integer(), nullable=True),
+    sa.Column('is_default', sa.Boolean(), nullable=False),
+    sa.Column('is_forced', sa.Boolean(), nullable=False),
+    sa.Column('title', sa.String(255), nullable=True),
+)

--- a/backend/app/migrations/versions/0001_legacy_baseline.py
+++ b/backend/app/migrations/versions/0001_legacy_baseline.py
@@ -1,0 +1,70 @@
+"""Adopt the initial, media-type, and pre-constraint ownership schemas."""
+
+from alembic import op
+import sqlalchemy as sa
+
+from app.core.encryption import encrypt_value, is_encrypted
+from app.migrations.schema_v1 import metadata
+
+revision = "0001_legacy_baseline"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    # Frozen schema: future model changes must get a new revision.
+    metadata.create_all(bind)
+
+    def columns(table):
+        return {column["name"] for column in sa.inspect(bind).get_columns(table)}
+
+    for table in ("shows", "media_files", "scan_locations"):
+        if "user_id" not in columns(table):
+            op.add_column(table, sa.Column("user_id", sa.Integer(), nullable=True))
+
+    if "media_type" not in columns("shows"):
+        op.add_column("shows", sa.Column("media_type", sa.String(20), nullable=True))
+    bind.execute(sa.text("UPDATE shows SET media_type = CASE WHEN is_anime THEN 'anime' ELSE 'tv' END WHERE media_type IS NULL"))
+
+    if "media_type" not in columns("scan_locations"):
+        op.add_column("scan_locations", sa.Column("media_type", sa.String(20), nullable=True))
+    expression = "CASE WHEN is_anime_folder THEN 'anime' ELSE 'tv' END" if "is_anime_folder" in columns("scan_locations") else "'tv'"
+    bind.execute(sa.text(f"UPDATE scan_locations SET media_type = {expression} WHERE media_type IS NULL"))
+
+    if "show_id" not in columns("media_files"):
+        op.add_column("media_files", sa.Column("show_id", sa.Integer(), nullable=True))
+    bind.execute(sa.text("""
+        UPDATE media_files SET show_id = (SELECT show_id FROM seasons WHERE seasons.id = media_files.season_id)
+        WHERE show_id IS NULL AND season_id IS NOT NULL
+    """))
+
+    needs_owner = any(bind.scalar(sa.text(f"SELECT COUNT(*) FROM {table} WHERE user_id IS NULL"))
+                      for table in ("shows", "media_files", "scan_locations"))
+    if needs_owner:
+        owner_id = bind.scalar(sa.text("SELECT MIN(id) FROM users"))
+        if owner_id is None:
+            users = metadata.tables["users"]
+            owner_id = bind.scalar(users.insert().values(
+                plex_user_id="bootstrap-owner", plex_username="bootstrap-owner",
+                plex_token=encrypt_value("bootstrap-owner-token"),
+                created_at=sa.func.current_timestamp(), last_login=sa.func.current_timestamp(),
+            ).returning(users.c.id))
+        bind.execute(sa.text("UPDATE shows SET user_id = :owner WHERE user_id IS NULL"), {"owner": owner_id})
+        # Prefer the file's show owner if an earlier partial migration assigned it.
+        bind.execute(sa.text("""
+            UPDATE media_files SET user_id = COALESCE(
+                (SELECT user_id FROM shows WHERE shows.id = media_files.show_id), :owner)
+            WHERE user_id IS NULL
+        """), {"owner": owner_id})
+        bind.execute(sa.text("UPDATE scan_locations SET user_id = :owner WHERE user_id IS NULL"), {"owner": owner_id})
+
+    for user_id, token in bind.execute(sa.text("SELECT id, plex_token FROM users")):
+        if token and not is_encrypted(token):
+            bind.execute(sa.text("UPDATE users SET plex_token = :token WHERE id = :id"),
+                         {"id": user_id, "token": encrypt_value(token)})
+
+
+def downgrade():
+    raise RuntimeError("Restore the pre-upgrade database backup to roll back this adoption migration.")

--- a/backend/app/migrations/versions/0002_ownership_constraints.py
+++ b/backend/app/migrations/versions/0002_ownership_constraints.py
@@ -1,0 +1,63 @@
+"""Enforce ownership, per-user paths, and foreign keys after orphan cleanup."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002_ownership_constraints"
+down_revision = "0001_legacy_baseline"
+branch_labels = None
+depends_on = None
+
+NAMING = {"fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+          "uq": "uq_%(table_name)s_%(column_0_name)s"}
+
+
+def upgrade():
+    bind = op.get_bind()
+    # Remove rows that should have cascaded with their deleted parent.
+    for table in ("user_preferences", "media_files", "shows", "scan_locations"):
+        bind.execute(sa.text(f"DELETE FROM {table} WHERE user_id NOT IN (SELECT id FROM users)"))
+    bind.execute(sa.text("DELETE FROM seasons WHERE show_id NOT IN (SELECT id FROM shows)"))
+    bind.execute(sa.text("DELETE FROM audio_tracks WHERE media_file_id NOT IN (SELECT id FROM media_files)"))
+    bind.execute(sa.text("UPDATE media_files SET season_id = NULL WHERE season_id NOT IN (SELECT id FROM seasons)"))
+    bind.execute(sa.text("UPDATE media_files SET show_id = NULL WHERE show_id NOT IN (SELECT id FROM shows)"))
+
+    for table in ("shows", "media_files", "scan_locations"):
+        inspector = sa.inspect(bind)
+        foreign_keys = inspector.get_foreign_keys(table)
+        constraints = inspector.get_unique_constraints(table)
+        columns = {col["name"]: col for col in inspector.get_columns(table)}
+        with op.batch_alter_table(table, naming_convention=NAMING) as batch:
+            batch.alter_column("user_id", existing_type=sa.Integer(), nullable=False)
+            if "media_type" in columns:
+                batch.alter_column("media_type", existing_type=sa.String(20), nullable=False)
+            expected_fks = [("user_id", "users", "CASCADE")]
+            if table == "media_files":
+                expected_fks.append(("show_id", "shows", "SET NULL"))
+            for column, parent, ondelete in expected_fks:
+                matches = [fk for fk in foreign_keys if fk["constrained_columns"] == [column]]
+                if matches and matches[0]["referred_table"] == parent and matches[0].get("options", {}).get("ondelete") == ondelete:
+                    continue
+                for fk in matches:
+                    name = fk["name"] or f"fk_{table}_{column}_{fk['referred_table']}"
+                    batch.drop_constraint(name, type_="foreignkey")
+                batch.create_foreign_key(f"fk_{table}_{column}_{parent}", parent, [column], ["id"], ondelete=ondelete)
+
+            old_path = "file_path" if table == "media_files" else "path" if table == "scan_locations" else None
+            for constraint in constraints:
+                if old_path and constraint["column_names"] == [old_path]:
+                    batch.drop_constraint(constraint["name"] or f"uq_{table}_{old_path}", type_="unique")
+            if table == "media_files":
+                batch.create_unique_constraint("uq_media_files_user_path", ["user_id", "file_path"])
+            if table == "scan_locations" and "is_anime_folder" in columns:
+                batch.drop_column("is_anime_folder")
+
+        index_names = {index["name"] for index in sa.inspect(bind).get_indexes(table)}
+        if f"ix_{table}_user_id" not in index_names:
+            op.create_index(f"ix_{table}_user_id", table, ["user_id"])
+        if table == "scan_locations" and "uq_scan_locations_user_path" not in index_names:
+            op.create_index("uq_scan_locations_user_path", table, ["user_id", "path"], unique=True)
+
+
+def downgrade():
+    raise RuntimeError("Per-user paths cannot safely become globally unique. Restore the pre-upgrade backup.")

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -3,8 +3,8 @@
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
-from sqlalchemy import event
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from app.models.engine import create_database_engine
 
 from app.config import get_settings
 
@@ -17,33 +17,7 @@ if settings.is_sqlite:
         db_path = db_path[2:]
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
 
-sqlite_connect_args = (
-    {
-        "check_same_thread": False,
-        # Wait up to 30s for pending write locks instead of failing fast.
-        "timeout": 30,
-    }
-    if settings.is_sqlite
-    else {}
-)
-
-# Create async engine
-engine = create_async_engine(
-    settings.database_url,
-    echo=settings.debug,
-    # SQLite-specific settings
-    connect_args=sqlite_connect_args,
-)
-
-if settings.is_sqlite:
-    # Reduce SQLITE_BUSY errors under concurrent read/write load.
-    @event.listens_for(engine.sync_engine, "connect")
-    def set_sqlite_pragma(dbapi_connection, _connection_record) -> None:
-        cursor = dbapi_connection.cursor()
-        cursor.execute("PRAGMA busy_timeout = 30000")
-        cursor.execute("PRAGMA journal_mode = WAL")
-        cursor.execute("PRAGMA synchronous = NORMAL")
-        cursor.close()
+engine = create_database_engine(settings.database_url, echo=settings.debug)
 
 # Session factory
 async_session_maker = async_sessionmaker(
@@ -69,14 +43,6 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 
 
 async def init_db() -> None:
-    """Initialize database tables."""
-    from app.models.entities import Base
-    from app.models.migrations import (
-        apply_ownership_migrations,
-        apply_token_encryption_migration,
-    )
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-        await apply_ownership_migrations(conn)
-        await apply_token_encryption_migration(conn)
+    """Upgrade the schema before serving any application requests."""
+    from app.models.migrations import upgrade_database
+    await upgrade_database(engine)

--- a/backend/app/models/engine.py
+++ b/backend/app/models/engine.py
@@ -1,0 +1,31 @@
+"""Engine construction shared by the application and database integration tests."""
+
+from sqlalchemy import event
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+def create_database_engine(url: str | URL, *, echo: bool = False):
+    sqlite = make_url(url).get_backend_name() == "sqlite"
+    engine = create_async_engine(
+        url, echo=echo,
+        connect_args={"check_same_thread": False, "timeout": 30} if sqlite else {},
+    )
+    if sqlite:
+        @event.listens_for(engine.sync_engine, "connect")
+        def configure_sqlite(connection, _record):
+            # Let SQLAlchemy start real transactions, including DDL and savepoints.
+            connection.isolation_level = None
+            cursor = connection.cursor()
+            cursor.execute("PRAGMA foreign_keys = ON")
+            cursor.execute("PRAGMA busy_timeout = 30000")
+            cursor.execute("PRAGMA journal_mode = WAL")
+            cursor.execute("PRAGMA synchronous = NORMAL")
+            cursor.close()
+
+        @event.listens_for(engine.sync_engine, "begin")
+        def begin_sqlite(connection):
+            mode = connection.get_execution_options().get("sqlite_transaction_mode", "")
+            connection.exec_driver_sql("BEGIN IMMEDIATE" if mode == "IMMEDIATE" else "BEGIN")
+
+    return engine

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -8,8 +8,8 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
 def _utcnow() -> datetime:
-    """Return current UTC time (timezone-aware)."""
-    return datetime.now(timezone.utc)
+    """Return UTC without an offset for the existing TIMESTAMP columns."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 class Base(DeclarativeBase):

--- a/backend/app/models/migrations.py
+++ b/backend/app/models/migrations.py
@@ -1,90 +1,54 @@
-"""Lightweight schema migrations for backward compatibility."""
+"""Transactional Alembic upgrades and the legacy token-backfill helper."""
 
-from __future__ import annotations
+from pathlib import Path
 
-from sqlalchemy import inspect, text
-from sqlalchemy.ext.asyncio import AsyncConnection
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import text
 
 from app.core.encryption import encrypt_value, is_encrypted
 
 
-async def _ensure_bootstrap_user(conn: AsyncConnection) -> int:
-    """Return an owner user id, creating a bootstrap owner when necessary."""
-    owner_id = await conn.scalar(text("SELECT MIN(id) FROM users"))
-    if owner_id is not None:
-        return int(owner_id)
-
-    result = await conn.execute(
-        text(
-            """
-            INSERT INTO users (plex_user_id, plex_username, plex_email, plex_token, plex_thumb_url, created_at, last_login)
-            VALUES ('bootstrap-owner', 'bootstrap-owner', NULL, :bootstrap_token, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-            """
-        ),
-        {"bootstrap_token": encrypt_value("bootstrap-owner-token")},
-    )
-
-    inserted_id = result.lastrowid
-    if inserted_id is not None:
-        return int(inserted_id)
-
-    owner_id = await conn.scalar(
-        text("SELECT id FROM users WHERE plex_user_id = 'bootstrap-owner' LIMIT 1")
-    )
-    return int(owner_id)
+async def apply_token_encryption_migration(conn):
+    """Retained for callers that explicitly backfill legacy token values."""
+    for user_id, token in (await conn.execute(text("SELECT id, plex_token FROM users"))):
+        if token and not is_encrypted(token):
+            await conn.execute(text("UPDATE users SET plex_token = :token WHERE id = :id"),
+                               {"id": user_id, "token": encrypt_value(token)})
 
 
-async def apply_token_encryption_migration(conn: AsyncConnection) -> None:
-    """Encrypt legacy plaintext Plex tokens in-place."""
-    result = await conn.execute(text("SELECT id, plex_token FROM users"))
-    users = result.fetchall()
-
-    for user_id, plex_token in users:
-        if plex_token and not is_encrypted(plex_token):
-            await conn.execute(
-                text("UPDATE users SET plex_token = :token WHERE id = :id"),
-                {"token": encrypt_value(plex_token), "id": user_id},
-            )
+def _set_sqlite_foreign_keys(connection, enabled):
+    # Use the DBAPI directly: PRAGMA must run outside the DDL transaction.
+    cursor = connection.connection.cursor()
+    try:
+        cursor.execute(f"PRAGMA foreign_keys = {'ON' if enabled else 'OFF'}")
+    finally:
+        cursor.close()
 
 
-async def apply_ownership_migrations(conn: AsyncConnection) -> None:
-    """Add per-user ownership columns and backfill old rows."""
-    for table_name in ("shows", "media_files", "scan_locations"):
-        columns = await conn.run_sync(
-            lambda sync_conn, current_table=table_name: {
-                c["name"]
-                for c in inspect(sync_conn).get_columns(current_table)
-            }
-        )
-        if "user_id" not in columns:
-            await conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN user_id INTEGER"))
+async def upgrade_database(engine, revision="head"):
+    """Commit every pending revision together, or roll all of them back."""
+    config = Config()
+    config.set_main_option("script_location", str(Path(__file__).parents[1] / "migrations"))
 
-    owner_id = await _ensure_bootstrap_user(conn)
+    def upgrade(connection):
+        config.attributes["connection"] = connection
+        command.upgrade(config, revision)
 
-    await conn.execute(
-        text("UPDATE shows SET user_id = :owner_id WHERE user_id IS NULL"),
-        {"owner_id": owner_id},
-    )
-    await conn.execute(
-        text("UPDATE media_files SET user_id = :owner_id WHERE user_id IS NULL"),
-        {"owner_id": owner_id},
-    )
-    await conn.execute(
-        text("UPDATE scan_locations SET user_id = :owner_id WHERE user_id IS NULL"),
-        {"owner_id": owner_id},
-    )
-
-    await conn.execute(
-        text(
-            "CREATE UNIQUE INDEX IF NOT EXISTS uq_scan_locations_user_path ON scan_locations (user_id, path)"
-        )
-    )
-    await conn.execute(
-        text("CREATE INDEX IF NOT EXISTS ix_shows_user_id ON shows (user_id)")
-    )
-    await conn.execute(
-        text("CREATE INDEX IF NOT EXISTS ix_media_files_user_id ON media_files (user_id)")
-    )
-    await conn.execute(
-        text("CREATE INDEX IF NOT EXISTS ix_scan_locations_user_id ON scan_locations (user_id)")
-    )
+    async with engine.connect() as connection:
+        sqlite = connection.dialect.name == "sqlite"
+        if sqlite:
+            await connection.run_sync(_set_sqlite_foreign_keys, False)
+            connection = await connection.execution_options(sqlite_transaction_mode="IMMEDIATE")
+        try:
+            async with connection.begin():
+                if not sqlite:
+                    await connection.execute(text("SELECT pg_advisory_xact_lock(843219706)"))
+                await connection.run_sync(upgrade)
+                if sqlite:
+                    violations = (await connection.exec_driver_sql("PRAGMA foreign_key_check")).fetchall()
+                    if violations:
+                        raise RuntimeError("Database upgrade left foreign-key violations; all changes were rolled back.")
+        finally:
+            if sqlite:
+                await connection.run_sync(_set_sqlite_foreign_keys, True)

--- a/backend/tests/fixtures/legacy_initial.py
+++ b/backend/tests/fixtures/legacy_initial.py
@@ -1,15 +1,12 @@
+# Historical fixture copied from c1d8f8db841e1297609c5ae781532bbe86aa3f14.
+# Preserve this schema; it must not follow current models.
 """SQLAlchemy ORM entity models."""
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, BigInteger, Text, Index, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, BigInteger, Text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
-
-
-def _utcnow() -> datetime:
-    """Return current UTC time (timezone-aware)."""
-    return datetime.now(timezone.utc)
 
 
 class Base(DeclarativeBase):
@@ -27,27 +24,18 @@ class User(Base):
     plex_user_id: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     plex_username: Mapped[str] = mapped_column(String(255), nullable=False)
     plex_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    plex_token: Mapped[str] = mapped_column(Text, nullable=False)
+    plex_token: Mapped[str] = mapped_column(Text, nullable=False)  # Encrypted
     plex_thumb_url: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=_utcnow, nullable=False
+        DateTime, default=datetime.utcnow, nullable=False
     )
     last_login: Mapped[datetime] = mapped_column(
-        DateTime, default=_utcnow, onupdate=_utcnow, nullable=False
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
     )
 
     # Relationships
     preferences: Mapped[list["UserPreference"]] = relationship(
         "UserPreference", back_populates="user", cascade="all, delete-orphan"
-    )
-    shows: Mapped[list["Show"]] = relationship(
-        "Show", back_populates="user", cascade="all, delete-orphan"
-    )
-    media_files: Mapped[list["MediaFile"]] = relationship(
-        "MediaFile", back_populates="user", cascade="all, delete-orphan"
-    )
-    scan_locations: Mapped[list["ScanLocation"]] = relationship(
-        "ScanLocation", back_populates="user", cascade="all, delete-orphan"
     )
 
 
@@ -68,18 +56,12 @@ class UserPreference(Base):
 
 
 class Show(Base):
-    """Media title model (movie, TV show, or anime)."""
+    """TV show model."""
 
     __tablename__ = "shows"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
-    )
     title: Mapped[str] = mapped_column(String(512), nullable=False)
-    media_type: Mapped[str] = mapped_column(
-        String(20), default="tv", nullable=False
-    )  # tv, movie, anime
     plex_key: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     plex_rating_key: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     is_anime: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
@@ -88,22 +70,15 @@ class Show(Base):
     )  # plex_genre, folder, manual
     thumb_url: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=_utcnow, nullable=False
+        DateTime, default=datetime.utcnow, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=_utcnow, onupdate=_utcnow, nullable=False
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
     )
 
     # Relationships
-    user: Mapped["User"] = relationship("User", back_populates="shows")
     seasons: Mapped[list["Season"]] = relationship(
         "Season", back_populates="show", cascade="all, delete-orphan"
-    )
-    media_files: Mapped[list["MediaFile"]] = relationship(
-        "MediaFile",
-        back_populates="show",
-        foreign_keys="MediaFile.show_id",
-        cascade="all, delete-orphan",
     )
 
 
@@ -131,19 +106,12 @@ class MediaFile(Base):
     """Media file model."""
 
     __tablename__ = "media_files"
-    __table_args__ = (UniqueConstraint("user_id", "file_path", name="uq_media_files_user_path"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
-    )
-    show_id: Mapped[Optional[int]] = mapped_column(
-        Integer, ForeignKey("shows.id", ondelete="SET NULL"), nullable=True
-    )
     season_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("seasons.id", ondelete="SET NULL"), nullable=True
     )
-    file_path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    file_path: Mapped[str] = mapped_column(String(1024), unique=True, nullable=False)
     filename: Mapped[str] = mapped_column(String(512), nullable=False)
     episode_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     episode_title: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
@@ -151,17 +119,13 @@ class MediaFile(Base):
     container_format: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     duration_ms: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
     last_scanned: Mapped[datetime] = mapped_column(
-        DateTime, default=_utcnow, nullable=False
+        DateTime, default=datetime.utcnow, nullable=False
     )
     last_modified: Mapped[datetime] = mapped_column(DateTime, nullable=False)
     has_issues: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     issue_details: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     # Relationships
-    user: Mapped["User"] = relationship("User", back_populates="media_files")
-    show: Mapped[Optional["Show"]] = relationship(
-        "Show", back_populates="media_files", foreign_keys=[show_id]
-    )
     season: Mapped[Optional["Season"]] = relationship(
         "Season", back_populates="media_files"
     )
@@ -204,23 +168,15 @@ class ScanLocation(Base):
     """Scan location configuration."""
 
     __tablename__ = "scan_locations"
-    __table_args__ = (Index("uq_scan_locations_user_path", "user_id", "path", unique=True),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
-    )
-    path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    path: Mapped[str] = mapped_column(String(1024), unique=True, nullable=False)
     label: Mapped[str] = mapped_column(String(255), nullable=False)
-    media_type: Mapped[str] = mapped_column(
-        String(20), default="tv", nullable=False
-    )  # tv, movie, anime
+    is_anime_folder: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     last_scanned: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     file_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=_utcnow, nullable=False
+        DateTime, default=datetime.utcnow, nullable=False
     )
 
-    # Relationships
-    user: Mapped["User"] = relationship("User", back_populates="scan_locations")

--- a/backend/tests/fixtures/legacy_pre_ownership.py
+++ b/backend/tests/fixtures/legacy_pre_ownership.py
@@ -1,9 +1,11 @@
+# Historical fixture copied from 3eccbf8192d539befc5d751b9062cc4077de1c1f.
+# Preserve this schema; it must not follow current models.
 """SQLAlchemy ORM entity models."""
 
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, BigInteger, Text, Index, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, BigInteger, Text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -27,7 +29,7 @@ class User(Base):
     plex_user_id: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     plex_username: Mapped[str] = mapped_column(String(255), nullable=False)
     plex_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    plex_token: Mapped[str] = mapped_column(Text, nullable=False)
+    plex_token: Mapped[str] = mapped_column(Text, nullable=False)  # Stored as plaintext — consider encrypting
     plex_thumb_url: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=_utcnow, nullable=False
@@ -39,15 +41,6 @@ class User(Base):
     # Relationships
     preferences: Mapped[list["UserPreference"]] = relationship(
         "UserPreference", back_populates="user", cascade="all, delete-orphan"
-    )
-    shows: Mapped[list["Show"]] = relationship(
-        "Show", back_populates="user", cascade="all, delete-orphan"
-    )
-    media_files: Mapped[list["MediaFile"]] = relationship(
-        "MediaFile", back_populates="user", cascade="all, delete-orphan"
-    )
-    scan_locations: Mapped[list["ScanLocation"]] = relationship(
-        "ScanLocation", back_populates="user", cascade="all, delete-orphan"
     )
 
 
@@ -73,9 +66,6 @@ class Show(Base):
     __tablename__ = "shows"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
-    )
     title: Mapped[str] = mapped_column(String(512), nullable=False)
     media_type: Mapped[str] = mapped_column(
         String(20), default="tv", nullable=False
@@ -95,7 +85,6 @@ class Show(Base):
     )
 
     # Relationships
-    user: Mapped["User"] = relationship("User", back_populates="shows")
     seasons: Mapped[list["Season"]] = relationship(
         "Season", back_populates="show", cascade="all, delete-orphan"
     )
@@ -131,19 +120,15 @@ class MediaFile(Base):
     """Media file model."""
 
     __tablename__ = "media_files"
-    __table_args__ = (UniqueConstraint("user_id", "file_path", name="uq_media_files_user_path"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
-    )
     show_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("shows.id", ondelete="SET NULL"), nullable=True
     )
     season_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("seasons.id", ondelete="SET NULL"), nullable=True
     )
-    file_path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    file_path: Mapped[str] = mapped_column(String(1024), unique=True, nullable=False)
     filename: Mapped[str] = mapped_column(String(512), nullable=False)
     episode_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     episode_title: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
@@ -158,7 +143,6 @@ class MediaFile(Base):
     issue_details: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     # Relationships
-    user: Mapped["User"] = relationship("User", back_populates="media_files")
     show: Mapped[Optional["Show"]] = relationship(
         "Show", back_populates="media_files", foreign_keys=[show_id]
     )
@@ -204,13 +188,9 @@ class ScanLocation(Base):
     """Scan location configuration."""
 
     __tablename__ = "scan_locations"
-    __table_args__ = (Index("uq_scan_locations_user_path", "user_id", "path", unique=True),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
-    )
-    path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    path: Mapped[str] = mapped_column(String(1024), unique=True, nullable=False)
     label: Mapped[str] = mapped_column(String(255), nullable=False)
     media_type: Mapped[str] = mapped_column(
         String(20), default="tv", nullable=False
@@ -222,5 +202,3 @@ class ScanLocation(Base):
         DateTime, default=_utcnow, nullable=False
     )
 
-    # Relationships
-    user: Mapped["User"] = relationship("User", back_populates="scan_locations")

--- a/backend/tests/test_database_migrations.py
+++ b/backend/tests/test_database_migrations.py
@@ -1,0 +1,262 @@
+"""Upgrade actual historical schemas on both supported database engines."""
+
+from datetime import datetime
+import os
+from pathlib import Path
+import shutil
+import sqlite3
+import subprocess
+from unittest.mock import patch
+from uuid import uuid4
+
+from alembic.autogenerate import compare_metadata
+from alembic.migration import MigrationContext
+import pytest
+import pytest_asyncio
+from sqlalchemy import event, inspect, select, text
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.backup import backup_sqlite
+from app.core.encryption import decrypt_value
+from app.core.scanner import MediaScanner
+from app.core.scan_state import scan_state_manager
+from app.migrations.schema_v1 import metadata as current_legacy
+from app.models.engine import create_database_engine
+from app.models.entities import Base, MediaFile, User
+from app.models.migrations import upgrade_database, _set_sqlite_foreign_keys
+from fixtures.legacy_initial import Base as Initial
+from fixtures.legacy_pre_ownership import Base as PreOwnership
+
+
+@pytest_asyncio.fixture(params=["sqlite", "postgres"])
+async def database(request, tmp_path):
+    if request.param == "sqlite":
+        engine = create_database_engine(f"sqlite+aiosqlite:///{tmp_path / 'source.db'}")
+        yield engine
+        await engine.dispose()
+        return
+    postgres_url = os.environ.get("TEST_POSTGRES_URL")
+    if not postgres_url:
+        pytest.skip("TEST_POSTGRES_URL is required for PostgreSQL integration tests")
+    url = make_url(postgres_url)
+    name = f"trackhound_test_{uuid4().hex}"
+    admin = create_async_engine(url, isolation_level="AUTOCOMMIT")
+    async with admin.connect() as connection:
+        await connection.execute(text(f'CREATE DATABASE "{name}"'))
+    engine = create_database_engine(url.set(database=name))
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+        async with admin.connect() as connection:
+            await connection.execute(text(f'DROP DATABASE "{name}" WITH (FORCE)'))
+        await admin.dispose()
+
+
+async def seed_legacy(engine, version):
+    metadata = {"initial": Initial.metadata, "pre_ownership": PreOwnership.metadata,
+                "current": current_legacy}[version]
+    now = datetime(2026, 1, 1)
+    async with engine.begin() as connection:
+        await connection.run_sync(metadata.create_all)
+
+        async def insert(table, **values):
+            table = metadata.tables[table]
+            return await connection.scalar(table.insert().values(**values).returning(table.c.id))
+
+        user_id = await insert("users", plex_user_id="123", plex_username="owner",
+                               plex_token="legacy-plex-token", created_at=now, last_login=now)
+        owner = {"user_id": user_id} if version == "current" else {}
+        show_id = await insert("shows", title="Test anime", is_anime=True, anime_source="folder",
+                               created_at=now, updated_at=now,
+                               **({"media_type": "anime"} if version != "initial" else {}), **owner)
+        season_id = await insert("seasons", show_id=show_id, season_number=1)
+        file_id = await insert("media_files", file_path="/media/anime/episode.mkv", filename="episode.mkv",
+                               season_id=season_id, file_size=100, last_modified=now, last_scanned=now,
+                               has_issues=False, **({"show_id": show_id} if version != "initial" else {}), **owner)
+        await insert("audio_tracks", media_file_id=file_id, track_index=0, language="ja",
+                     is_default=True, is_forced=False, title="Original audio")
+        await insert("scan_locations", path="/media/anime", label="Anime", enabled=True,
+                     file_count=1, created_at=now,
+                     **({"is_anime_folder": True} if version == "initial" else {"media_type": "anime"}), **owner)
+        await insert("user_preferences", user_id=user_id, key="audio_preferences",
+                     value='{"require_japanese_anime":true}')
+
+
+async def assert_upgraded(engine):
+    async with engine.connect() as connection:
+        assert await connection.scalar(text("SELECT version_num FROM alembic_version")) == "0002_ownership_constraints"
+        diffs = await connection.run_sync(lambda sync: compare_metadata(MigrationContext.configure(sync), Base.metadata))
+        assert diffs == []
+        if connection.dialect.name == "sqlite":
+            assert await connection.scalar(text("PRAGMA foreign_keys")) == 1
+            assert not (await connection.execute(text("PRAGMA foreign_key_check"))).all()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("version", ["initial", "pre_ownership", "current"])
+async def test_historical_upgrade_preserves_rows_and_matches_models(database, version):
+    await seed_legacy(database, version)
+    await upgrade_database(database)
+    await assert_upgraded(database)
+    async with database.connect() as connection:
+        assert decrypt_value(await connection.scalar(text("SELECT plex_token FROM users WHERE plex_user_id='123'"))) == "legacy-plex-token"
+        row = (await connection.execute(text("SELECT user_id, show_id, season_id, file_size FROM media_files"))).one()
+        assert tuple(row) == (1, 1, 1, 100)
+        assert await connection.scalar(text("SELECT media_type FROM scan_locations")) == "anime"
+        assert await connection.scalar(text("SELECT title FROM audio_tracks")) == "Original audio"
+        assert await connection.scalar(text("SELECT COUNT(*) FROM user_preferences")) == 1
+    await upgrade_database(database)
+    await assert_upgraded(database)
+
+
+@pytest.mark.asyncio
+async def test_fresh_upgrade_matches_models(database):
+    await upgrade_database(database)
+    await assert_upgraded(database)
+
+
+@pytest.mark.asyncio
+async def test_failed_upgrade_rolls_back_schema_rows_and_revision(database):
+    await seed_legacy(database, "initial")
+
+    def fail_late(_connection, _cursor, statement, _parameters, _context, _executemany):
+        if "CREATE INDEX ix_shows_user_id" in statement:
+            raise RuntimeError("injected late migration failure")
+
+    event.listen(database.sync_engine, "before_cursor_execute", fail_late)
+    try:
+        with pytest.raises(RuntimeError, match="injected"):
+            await upgrade_database(database)
+    finally:
+        event.remove(database.sync_engine, "before_cursor_execute", fail_late)
+    async with database.connect() as connection:
+        columns = await connection.run_sync(lambda sync: {col["name"] for col in inspect(sync).get_columns("shows")})
+        assert "user_id" not in columns
+        assert not await connection.run_sync(lambda sync: inspect(sync).has_table("alembic_version"))
+        assert await connection.scalar(text("SELECT plex_token FROM users")) == "legacy-plex-token"
+        assert await connection.scalar(text("SELECT COUNT(*) FROM audio_tracks")) == 1
+    await upgrade_database(database)
+    await assert_upgraded(database)
+
+
+@pytest.mark.asyncio
+async def test_orphan_cleanup_and_database_cascade(database):
+    await seed_legacy(database, "initial")
+    async with database.connect() as connection:
+        sqlite = connection.dialect.name == "sqlite"
+        if sqlite:
+            await connection.run_sync(_set_sqlite_foreign_keys, False)
+        async with connection.begin():
+            if not sqlite:
+                fk = (await connection.run_sync(lambda sync: inspect(sync).get_foreign_keys("audio_tracks")))[0]
+                await connection.execute(text(f'ALTER TABLE audio_tracks DROP CONSTRAINT "{fk["name"]}"'))
+            await connection.execute(text("INSERT INTO audio_tracks (media_file_id, track_index, is_default, is_forced) VALUES (999, 1, FALSE, FALSE)"))
+            if not sqlite:
+                # NOT VALID allows the historical orphan but still models the old FK.
+                await connection.execute(text("ALTER TABLE audio_tracks ADD CONSTRAINT audio_tracks_media_file_id_fkey FOREIGN KEY (media_file_id) REFERENCES media_files(id) ON DELETE CASCADE NOT VALID"))
+        if sqlite:
+            await connection.run_sync(_set_sqlite_foreign_keys, True)
+    await upgrade_database(database)
+    async with database.begin() as connection:
+        assert await connection.scalar(text("SELECT COUNT(*) FROM audio_tracks")) == 1
+        await connection.execute(text("DELETE FROM media_files"))
+        assert await connection.scalar(text("SELECT COUNT(*) FROM audio_tracks")) == 0
+
+
+@pytest.mark.asyncio
+async def test_shared_paths_and_failed_file_do_not_poison_the_scan(database, tmp_path):
+    await upgrade_database(database)
+    source = tmp_path / "movie.mkv"
+    source.write_bytes(b"probe is mocked")
+    async with async_sessionmaker(database, expire_on_commit=False)() as session:
+        users = [User(plex_user_id=str(n), plex_username=str(n), plex_token="test") for n in (123, 456)]
+        session.add_all(users)
+        await session.commit()
+        scanner = MediaScanner()
+        await scan_state_manager.reset()
+        with patch.object(scanner.analyzer, "analyze", return_value={"audio_tracks": []}):
+            for user in users:
+                assert await scanner.process_file(str(source), str(tmp_path), "movie", user.id, session)
+            await session.commit()
+            assert len((await session.scalars(select(MediaFile))).all()) == 2
+            # Deliberate constraint failure inside one per-file savepoint.
+            invalid = tmp_path / "bad.mkv"
+            invalid.write_bytes(b"bad")
+            assert await scanner.process_file(str(invalid), str(tmp_path), "movie", 9999, session) is None
+            valid = tmp_path / "valid.mkv"
+            valid.write_bytes(b"valid")
+            assert await scanner.process_file(str(valid), str(tmp_path), "movie", users[0].id, session)
+            await session.commit()
+        stored = (await session.scalars(select(MediaFile).where(MediaFile.file_path == str(source)))).first()
+        with pytest.raises(IntegrityError):
+            async with session.begin_nested():
+                session.add(MediaFile(user_id=stored.user_id, file_path=stored.file_path, filename="duplicate",
+                                      file_size=1, last_modified=datetime.now()))
+                await session.flush()
+        assert len((await session.scalars(select(MediaFile))).all()) == 3
+        await scan_state_manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_backup_upgrade_restore(database, tmp_path):
+    await seed_legacy(database, "initial")
+    sqlite = database.dialect.name == "sqlite"
+    backup = tmp_path / ("snapshot.db" if sqlite else "snapshot.dump")
+    if sqlite:
+        backup_sqlite(Path(database.url.database), backup)
+    else:
+        container = os.environ.get("TEST_POSTGRES_CONTAINER")
+        if not container and (not shutil.which("pg_dump") or not shutil.which("pg_restore")):
+            pytest.fail("PostgreSQL recovery tests require pg_dump and pg_restore")
+        url = database.url
+        environment = {**os.environ, "PGHOST": url.host, "PGPORT": str(url.port or 5432),
+                       "PGUSER": url.username, "PGPASSWORD": url.password, "PGDATABASE": url.database}
+        prefix = ["docker", "exec", "-i", container] if container else []
+        # CI uses the server's own matching pg_dump/pg_restore version.
+        dump = subprocess.run([*prefix, "pg_dump", "-U", url.username, "--dbname", url.database, "--format=custom"],
+                              env=environment, check=True, capture_output=True, timeout=60)
+        backup.write_bytes(dump.stdout)
+    await upgrade_database(database)
+    await assert_upgraded(database)
+    await database.dispose()
+    if sqlite:
+        with sqlite3.connect(backup) as original, sqlite3.connect(database.url.database) as restored:
+            original.backup(restored)
+    else:
+        # This fixture owns an isolated, disposable database, never the supplied admin DB.
+        assert database.url.database.startswith("trackhound_test_")
+        async with database.begin() as connection:
+            await connection.execute(text("DROP SCHEMA public CASCADE"))
+            await connection.execute(text("CREATE SCHEMA public"))
+        await database.dispose()
+        subprocess.run([*prefix, "pg_restore", "-U", url.username, "--exit-on-error", "--single-transaction", "--no-owner",
+                        "--dbname", url.database], input=backup.read_bytes(), env=environment,
+                       check=True, capture_output=True, timeout=60)
+    async with database.connect() as connection:
+        assert not await connection.run_sync(lambda sync: inspect(sync).has_table("alembic_version"))
+        assert await connection.scalar(text("SELECT plex_token FROM users")) == "legacy-plex-token"
+        assert await connection.scalar(text("SELECT COUNT(*) FROM media_files")) == 1
+        assert await connection.scalar(text("SELECT title FROM audio_tracks")) == "Original audio"
+    await upgrade_database(database)
+    await assert_upgraded(database)
+
+
+def test_sqlite_backup_includes_wal_and_never_overwrites(tmp_path):
+    source, backup = tmp_path / "source.db", tmp_path / "snapshot.db"
+    with sqlite3.connect(source) as connection:
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA wal_autocheckpoint=0")
+        connection.execute("CREATE TABLE sample (value TEXT)")
+        connection.execute("INSERT INTO sample VALUES ('committed in WAL')")
+        connection.commit()
+        assert source.with_name("source.db-wal").stat().st_size > 0
+        backup_sqlite(source, backup)
+        before = backup.read_bytes()
+        with pytest.raises(FileExistsError):
+            backup_sqlite(source, backup)
+        assert backup.read_bytes() == before
+    with sqlite3.connect(backup) as restored:
+        assert restored.execute("SELECT value FROM sample").fetchone()[0] == "committed in WAL"

--- a/docs/IMPLEMENTATION_PROGRESS.md
+++ b/docs/IMPLEMENTATION_PROGRESS.md
@@ -82,3 +82,13 @@ the local editing environment.
 Existing issues are at `https://github.com/TheSoloGreen/TrackHound/issues/<number>`.
 When resuming, inspect the branch and PR checks first, preserve completed work,
 then select the next bounded batch from this table.
+
+## Database follow-up: fix/database-integrity
+
+This branch depends on fix/secure-media-editing and adds the versioned historical
+upgrade path (#27), per-user file uniqueness and per-file savepoints (#33),
+SQLite foreign-key enforcement with orphan cleanup (#39), and consistent backup
+commands plus backup/upgrade/restore integration tests (#41). Historical fixtures
+come from the actual initial and pre-ownership commits. PostgreSQL tests run
+against isolated databases in the CI service. See OPERATIONS.md for the required
+backup and rollback procedure. Later scan and UI issues are still in progress.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -19,8 +19,18 @@
    Explicitly enable writes and writable media mounts only for libraries you
    intend TrackHound to edit.
 
-This change adds no database columns. Existing migration behavior is unchanged;
-versioned database migrations remain a separate follow-up.
+Startup now upgrades through a versioned Alembic chain before serving requests.
+All pending schema changes commit together; an error rolls the entire upgrade back
+and prevents startup. SQLite table rebuilds run under one write transaction, with
+foreign keys checked before commit and re-enabled afterward. PostgreSQL upgrades
+use a transaction and an advisory lock.
+
+The baseline covers the initial, pre-ownership, and previously unversioned schemas.
+As in the earlier ownership migration, unowned legacy rows go to the oldest stored
+user, or an inactive bootstrap owner if no user exists. Rows whose parents were
+already deleted are cleaned up before foreign keys are enforced. Back up first;
+inspect legacy ownership before exposing a restored instance to additional users.
+Future schema changes require new revisions; do not edit applied revisions.
 
 ## Keys and Plex reconnection
 
@@ -88,3 +98,107 @@ separately when needed.
 
 If rolling back an image after future schema changes, use the backup associated
 with that image rather than assuming an older version understands a newer schema.
+
+## SQLite backup and restore commands
+
+The backup command uses SQLite's online backup API, so committed WAL changes are
+included without copying a live database file. It verifies integrity and refuses
+to overwrite a previous backup. Run these from the Docker host; adjust the
+container name if yours differs:
+
+```bash
+TRACKHOUND_BACKUP="trackhound-$(date -u +%Y%m%dT%H%M%SZ).db"
+docker exec trackhound python -m app.backup /app/data/trackhound.db "/tmp/$TRACKHOUND_BACKUP"
+docker cp "trackhound:/tmp/$TRACKHOUND_BACKUP" "./$TRACKHOUND_BACKUP"
+```
+
+Back up `.env` and the exact deployed image digest separately. A pre-upgrade
+backup should be taken after stopping scans and edits. Verify the copied snapshot:
+
+```bash
+python - "$TRACKHOUND_BACKUP" <<'PY'
+import sqlite3, sys
+from pathlib import Path
+with sqlite3.connect(Path(sys.argv[1]).resolve().as_uri() + '?mode=ro', uri=True) as db:
+    print(db.execute('PRAGMA integrity_check').fetchone()[0])
+    print('Media rows:', db.execute('SELECT COUNT(*) FROM media_files').fetchone()[0])
+PY
+```
+
+To restore, stop the container and preserve the complete current data directory.
+Restore into a new directory so old `-wal`/`-shm` files cannot be replayed onto the
+snapshot. For the example Unraid mapping:
+
+```bash
+docker stop trackhound
+TRACKHOUND_RESTORE_DIR="/mnt/user/appdata/trackhound-restore-$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir "$TRACKHOUND_RESTORE_DIR"
+cp -- "$TRACKHOUND_BACKUP" "$TRACKHOUND_RESTORE_DIR/trackhound.db"
+chown -R 1000:1000 "$TRACKHOUND_RESTORE_DIR"
+```
+
+Change the container's `/app/data` mapping to that new directory, restore the
+matching encryption key/configuration, and start the intended image version with
+media writes disabled. The previous directory remains available for recovery.
+Check health, sign-in, saved locations, row counts, and a sample rescan. Reverting
+the volume mapping alone is insufficient if you also changed the encryption key.
+
+## PostgreSQL dump, restore, and volume replacement
+
+Use the database container's own client binaries so dump/restore versions match.
+The examples use the committed PostgreSQL Compose file and its default database
+name and user. Run while no scan or edit is active:
+
+```bash
+TRACKHOUND_PG_BACKUP="trackhound-$(date -u +%Y%m%dT%H%M%SZ).dump"
+docker compose -f docker-compose.postgres.yml exec -T db pg_dump -U trackhound -d trackhound --format=custom > "$TRACKHOUND_PG_BACKUP"
+docker compose -f docker-compose.postgres.yml exec -T db pg_restore --list < "$TRACKHOUND_PG_BACKUP"
+```
+
+Check both commands' exit status before relying on the dump. Store the matching
+`.env`, image digest, and migration version with it. A full dump includes the
+migration-version table. To restore without deleting the existing volume, stop the
+application and create a new named volume:
+
+```bash
+docker compose -f docker-compose.postgres.yml stop trackhound
+TRACKHOUND_RESTORE_VOLUME="trackhound-postgres-restore-$(date -u +%Y%m%dT%H%M%SZ)"
+docker volume create "$TRACKHOUND_RESTORE_VOLUME"
+cat > restore.override.yml <<YAML
+volumes:
+  postgres_data:
+    name: $TRACKHOUND_RESTORE_VOLUME
+    external: true
+YAML
+docker compose -f docker-compose.postgres.yml -f restore.override.yml up -d db
+```
+
+Wait until `docker compose -f docker-compose.postgres.yml -f restore.override.yml
+ps` reports the database healthy, then restore into its empty database:
+
+```bash
+docker compose -f docker-compose.postgres.yml -f restore.override.yml exec -T db pg_restore -U trackhound --dbname=trackhound --exit-on-error --single-transaction --no-owner < "$TRACKHOUND_PG_BACKUP"
+docker compose -f docker-compose.postgres.yml -f restore.override.yml exec -T db psql -U trackhound -d trackhound -c 'SELECT COUNT(*) FROM media_files;'
+docker compose -f docker-compose.postgres.yml -f restore.override.yml up -d trackhound
+```
+
+Keep the override file in use while this restored volume is active. Omitting it
+selects the original volume again. Never run `down -v` as part of this procedure.
+To roll back the application and schema, select the pre-upgrade image digest and
+restore its matching pre-upgrade database backup and keys. Alembic downgrades are
+intentionally blocked for the legacy adoption and per-user uniqueness changes;
+collapsing shared paths back into a global constraint could discard data.
+
+CI rehearses backup → upgrade → restore → upgrade on both SQLite and PostgreSQL
+with users, settings, locations, shows, seasons, files, and audio tracks. It also
+injects a late migration failure and checks that schema, data, token encryption,
+and migration version all roll back.
+
+## Reverse proxy and instance trust
+
+Use HTTPS at the reverse proxy, restrict direct access to the backend port, and
+set `CORS_ORIGINS` to the exact browser origin. Avoid exposing the Unraid management
+interface alongside the application. Keep the account allowlist small: approved
+users are trusted instance operators and share the configured mounted filesystem.
+The allowlist is enforced on every authenticated API request; proxy identity
+headers do not grant access. Keep writable media mounts limited to intended paths.


### PR DESCRIPTION
Older TrackHound databases can lack required columns and constraints, and a failed file insert can poison the rest of a scan. This PR adds a transactional Alembic upgrade path for the actual initial, pre-ownership, and unversioned schemas; enforces per-user file paths and SQLite foreign keys; cleans orphan rows; and isolates each file in a savepoint.

It also adds a consistent SQLite online-backup command, concrete SQLite/PostgreSQL recovery instructions, and backup → upgrade → restore integration tests. Historical fixture schemas are copied from their original repository commits. PostgreSQL tests use isolated CI databases and the server's matching dump/restore binaries.

Validation: all 98 backend tests passed in CI, including PostgreSQL upgrades, recovery, and real MKV editing. Frontend and container/Compose checks also passed. CI exposed a pre-existing mismatch between timezone-aware Python values and PostgreSQL's timestamp columns; this PR fixes those writes while preserving the existing storage format. [Passing run](https://github.com/TheSoloGreen/TrackHound/actions/runs/34246689042). The existing workflow now runs on dependent PRs and checks missing required Compose keys as well as valid configurations.

**Dependency and merge order:** merge #42 first, then this PR into `master`. This PR targets `fix/secure-media-editing` to keep its review focused. No production database or deployment has been changed.

**Upgrade requirement:** back up the database and retain its matching encryption key before upgrading. Startup commits all pending revisions together or rolls them back on error. Rollback of the historical adoption/per-user uniqueness changes uses a matching backup; destructive downgrades are deliberately blocked. See `docs/OPERATIONS.md`.

Fixes #27, fixes #33, fixes #39, fixes #41. Also completes deployment guidance for #40 and required-key checks for #26.