### PR TITLE
Honor scan settings, tolerate Plex failures, and safely reconcile missing files

### DIFF
--- a/backend/app/api/media.py
+++ b/backend/app/api/media.py
@@ -39,6 +39,7 @@ router = APIRouter()
 
 from app.core.analyzer import AudioAnalyzer, AudioAnalysisError, require_successful_analysis
 from app.core.media_access import get_media_edit_capabilities
+from app.core.classification import classify_show
 from app.core.preference_engine import PreferenceEngine, AudioPreferences
 from app.core.audio_fixer import (
     AudioTrackRemovalError,
@@ -544,6 +545,7 @@ async def list_shows(
                 id=show.id,
                 title=show.title,
                 media_type=show.media_type,
+                base_media_type=show.base_media_type,
                 is_anime=show.is_anime,
                 anime_source=show.anime_source,
                 thumb_url=show.thumb_url,
@@ -633,6 +635,7 @@ async def get_show(
         id=show.id,
         title=show.title,
         media_type=show.media_type,
+        base_media_type=show.base_media_type,
         is_anime=show.is_anime,
         anime_source=show.anime_source,
         thumb_url=show.thumb_url,
@@ -664,19 +667,18 @@ async def update_show(
             detail="Title not found",
         )
 
-    if updates.media_type is not None:
-        show.media_type = updates.media_type
-        if updates.media_type == "anime":
-            show.is_anime = True
-        elif updates.media_type in ("tv", "movie"):
-            show.is_anime = False
-    if updates.is_anime is not None:
-        show.is_anime = updates.is_anime
-        if updates.is_anime and not show.anime_source:
-            show.anime_source = "manual"
-    if updates.anime_source is not None:
-        show.anime_source = updates.anime_source
-
+    if updates.media_type is not None or updates.is_anime is not None:
+        base_type = updates.media_type.value if updates.media_type in ("tv", "movie") else show.base_media_type
+        is_anime = updates.is_anime if updates.is_anime is not None else updates.media_type == "anime"
+        classify_show(show, is_anime, "manual", base_type)
+        # Re-evaluate cached tracks immediately; classification does not edit media.
+        engine = PreferenceEngine(await _load_user_audio_preferences(db, current_user.id))
+        files = (await db.scalars(select(MediaFile).options(selectinload(MediaFile.audio_tracks)).where(
+            MediaFile.show_id == show.id, MediaFile.user_id == current_user.id))).all()
+        for media_file in files:
+            issues = engine.evaluate([_audio_track_to_dict(track) for track in media_file.audio_tracks], is_anime=show.is_anime)
+            media_file.has_issues = bool(issues)
+            media_file.issue_details = "; ".join(issues) if issues else None
     await db.flush()
 
     # Counts
@@ -711,6 +713,7 @@ async def update_show(
         id=show.id,
         title=show.title,
         media_type=show.media_type,
+        base_media_type=show.base_media_type,
         is_anime=show.is_anime,
         anime_source=show.anime_source,
         thumb_url=show.thumb_url,

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -343,6 +343,14 @@ async def start_scan(
     # Import here to avoid circular imports
     from app.core.scanner import run_scan
 
+    # An unreadable saved Plex token must not prevent local filesystem scanning.
+    plex_warning = None
+    try:
+        plex_token = decrypt_value(current_user.plex_token)
+    except ValueError:
+        plex_token = None
+        plex_warning = "Stored Plex credentials are unavailable. Local scanning continues; sign in again to reconnect Plex."
+
     # Start scan in background
     background_tasks.add_task(
         run_scan,
@@ -350,7 +358,8 @@ async def start_scan(
         location_media_types={loc.path: loc.media_type for loc in locations},
         incremental=request.incremental,
         user_id=current_user.id,
-        user_plex_token=decrypt_value(current_user.plex_token),
+        user_plex_token=plex_token,
+        plex_warning=plex_warning,
     )
 
     return started_status

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -1,45 +1,22 @@
 """Settings API endpoints for user preferences."""
 
 import json
-import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import ValidationError
+from fastapi import APIRouter, Depends
 from sqlalchemy import select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import get_current_user
+from app.core.user_settings import load_user_settings
 from app.models.database import get_db
 from app.models.entities import User, UserPreference
 from app.models.schemas import (
     UserSettingsResponse,
     UserSettingsUpdate,
-    AudioPreferences,
-    AnimeDetectionSettings,
 )
 
 router = APIRouter()
-
-# Default settings
-DEFAULT_AUDIO_PREFERENCES = AudioPreferences()
-DEFAULT_ANIME_DETECTION = AnimeDetectionSettings()
-DEFAULT_FILE_EXTENSIONS = [".mkv", ".mp4", ".avi", ".m4v"]
-
-
-async def get_user_preference(
-    db: AsyncSession, user_id: int, key: str
-) -> str | None:
-    """Get a user preference value."""
-    result = await db.execute(
-        select(UserPreference).where(
-            UserPreference.user_id == user_id,
-            UserPreference.key == key,
-        )
-    )
-    pref = result.scalar_one_or_none()
-    return pref.value if pref else None
-
 
 async def set_user_preference(
     db: AsyncSession, user_id: int, key: str, value: str
@@ -66,41 +43,7 @@ async def get_settings(
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
     """Get user settings."""
-    # Audio preferences
-    audio_json = await get_user_preference(db, current_user.id, "audio_preferences")
-    if audio_json:
-        try:
-            audio_prefs = AudioPreferences.model_validate_json(audio_json)
-        except ValidationError:
-            audio_prefs = DEFAULT_AUDIO_PREFERENCES
-    else:
-        audio_prefs = DEFAULT_AUDIO_PREFERENCES
-
-    # Anime detection
-    anime_json = await get_user_preference(db, current_user.id, "anime_detection")
-    if anime_json:
-        try:
-            anime_detection = AnimeDetectionSettings.model_validate_json(anime_json)
-        except ValidationError:
-            anime_detection = DEFAULT_ANIME_DETECTION
-    else:
-        anime_detection = DEFAULT_ANIME_DETECTION
-
-    # File extensions
-    ext_json = await get_user_preference(db, current_user.id, "file_extensions")
-    if ext_json:
-        try:
-            file_extensions = json.loads(ext_json)
-        except (json.JSONDecodeError, TypeError):
-            file_extensions = DEFAULT_FILE_EXTENSIONS
-    else:
-        file_extensions = DEFAULT_FILE_EXTENSIONS
-
-    return UserSettingsResponse(
-        audio_preferences=audio_prefs,
-        anime_detection=anime_detection,
-        file_extensions=file_extensions,
-    )
+    return await load_user_settings(db, current_user.id)
 
 
 @router.put("", response_model=UserSettingsResponse)

--- a/backend/app/core/classification.py
+++ b/backend/app/core/classification.py
@@ -1,0 +1,9 @@
+"""Keep the library category and the audio-analysis classification in agreement."""
+
+
+def classify_show(show, is_anime: bool, source: str | None, base_media_type: str | None = None):
+    base = base_media_type or show.base_media_type or ("movie" if show.media_type == "movie" else "tv")
+    show.base_media_type = base
+    show.media_type = "anime" if is_anime else base
+    show.is_anime = is_anime
+    show.anime_source = source if is_anime or source == "manual" else None

--- a/backend/app/core/plex_connector.py
+++ b/backend/app/core/plex_connector.py
@@ -49,6 +49,7 @@ class PlexConnector:
         self.token = token
         self.server_url = server_url
         self._server = None
+        self._library_loaded = False
         self._shows_cache: dict[str, PlexShow] = {}  # title variant -> show
         self._file_path_cache: dict[str, PlexShow] = {}  # normalized path -> show
         self._shows_by_key: dict[str, PlexShow] = {}  # rating_key -> show
@@ -67,16 +68,16 @@ class PlexConnector:
             
             if self.server_url:
                 # Direct connection to server
-                self._server = PlexServer(self.server_url, self.token)
+                self._server = PlexServer(self.server_url, self.token, timeout=10)
             else:
                 # Auto-discover from account
-                account = MyPlexAccount(token=self.token)
+                account = MyPlexAccount(token=self.token, timeout=10)
                 resources = account.resources()
                 
                 # Find first server
                 for resource in resources:
                     if resource.provides == "server":
-                        self._server = resource.connect()
+                        self._server = resource.connect(timeout=10)
                         break
                 
                 if not self._server:
@@ -231,6 +232,7 @@ class PlexConnector:
                     if folder:
                         self._shows_cache[folder.lower()] = plex_show
         
+        self._library_loaded = library_name is None
         return shows
 
     def _is_anime(self, genres: list[str]) -> bool:
@@ -246,7 +248,7 @@ class PlexConnector:
         This is the most reliable matching method.
         """
         # Ensure cache is populated
-        if not self._file_path_cache:
+        if not self._library_loaded:
             self.get_tv_shows()
         
         normalized = self._normalize_path(file_path)
@@ -276,7 +278,7 @@ class PlexConnector:
         Tries: exact match, original title match, fuzzy match.
         """
         # Ensure cache is populated
-        if not self._shows_cache:
+        if not self._library_loaded:
             self.get_tv_shows()
         
         title_lower = title.lower().strip()
@@ -468,7 +470,7 @@ class PlexConnector:
         
         Useful for debugging matching issues.
         """
-        if not self._shows_cache:
+        if not self._library_loaded:
             self.get_tv_shows()
         
         mappings = {}

--- a/backend/app/core/scan_state.py
+++ b/backend/app/core/scan_state.py
@@ -34,6 +34,7 @@ class ScanStateManager:
             self._cancel_requested_by_user[user_id] = False
             self._status_by_user[user_id] = ScanStatus(
                 is_running=True,
+                outcome="running",
                 current_location=None,
                 files_scanned=0,
                 files_total=0,
@@ -70,13 +71,27 @@ class ScanStateManager:
         """Append an error message to scan status."""
         async with self._lock:
             status = self._get_or_create_status(user_id)
-            status.errors.append(error)
+            status.error_count += 1
+            if len(status.errors) < 50:
+                status.errors.append(error)
             return status.model_copy(deep=True)
 
-    async def finish_scan(self, user_id: int) -> ScanStatus:
+    async def append_warning(self, user_id: int, warning: str) -> ScanStatus:
+        async with self._lock:
+            status = self._get_or_create_status(user_id)
+            status.warning_count += 1
+            if len(status.warnings) < 50:
+                status.warnings.append(warning)
+            return status.model_copy(deep=True)
+
+    async def finish_scan(self, user_id: int, *, failed: bool = False) -> ScanStatus:
         """Transition to not running while keeping progress context."""
         async with self._lock:
             status = self._get_or_create_status(user_id)
+            cancelled = self._cancel_requested_by_user.get(user_id, False)
+            status.outcome = ("failed" if failed else "cancelled" if cancelled else
+                              "completed_with_errors" if status.error_count or status.warning_count else "completed")
+            status.finished_at = datetime.now(timezone.utc)
             self._cancel_requested_by_user[user_id] = False
             status.is_running = False
             status.current_location = None

--- a/backend/app/core/scanner.py
+++ b/backend/app/core/scanner.py
@@ -1,23 +1,27 @@
 """Media file scanner for discovering and processing media files."""
 
+import asyncio
 import logging
+import stat as stat_module
 import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-from sqlalchemy import select, func
+from sqlalchemy import select, func, delete, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.database import async_session_maker
-from app.models.entities import MediaFile, Show, Season, ScanLocation, UserPreference
+from app.models.entities import MediaFile, Show, Season, ScanLocation, AudioTrack
 from app.core.analyzer import AudioAnalyzer, require_successful_analysis
 from app.core.media_access import get_media_edit_capabilities
 from app.core.plex_connector import PlexConnector
 from app.core.preference_engine import PreferenceEngine, AudioPreferences
 from app.core.audio_fixer import set_default_track_by_index
-from app.models.schemas import AudioPreferences as AudioPreferencesSchema
+from app.models.schemas import AnimeDetectionSettings, normalize_file_extensions
+from app.core.user_settings import load_user_settings
+from app.core.classification import classify_show
 from app.core.scan_state import scan_state_manager
 
 logger = logging.getLogger(__name__)
@@ -101,18 +105,15 @@ def parse_movie_title(file_path: str, base_path: str) -> str:
 
 
 class MediaScanner:
-    """Scanner for discovering media files in configured locations."""
+    """Scan one user's library using a snapshot of their saved preferences."""
 
-    def __init__(
-        self,
-        extensions: set[str] = None,
-        plex_token: Optional[str] = None,
-        audio_preferences: Optional[AudioPreferences] = None,
-    ):
-        self.extensions = extensions or DEFAULT_EXTENSIONS
+    def __init__(self, extensions=None, plex_token=None, audio_preferences=None, anime_detection=None):
+        self.extensions = set(normalize_file_extensions(list(extensions))) if extensions is not None else DEFAULT_EXTENSIONS
         self.analyzer = AudioAnalyzer()
         self.plex_connector = PlexConnector(plex_token) if plex_token else None
+        self.plex_failed = False
         self.preference_engine = PreferenceEngine(audio_preferences)
+        self.anime_detection = anime_detection or AnimeDetectionSettings()
 
     def _get_english_default_fix_index(self, audio_tracks: list[dict]) -> Optional[int]:
         """Return the English track index to promote as default, if needed."""
@@ -160,362 +161,232 @@ class MediaScanner:
         return audio_info
 
     def discover_files(self, location: str) -> list[str]:
-        """Discover all media files in a location."""
+        """Fail the location on unreadable directories instead of returning a partial list."""
+        root_path = Path(location).resolve(strict=True)
+        if not root_path.is_dir():
+            raise ValueError(f"Location is not a directory: {location}")
         files = []
-        location_path = Path(location)
 
-        if not location_path.exists():
-            raise ValueError(f"Location does not exist: {location}")
+        def fail(error):
+            raise error
 
-        for root, _, filenames in os.walk(location_path):
-            for filename in filenames:
-                if filename.startswith(".trackhound-"):
+        for root, _, names in os.walk(root_path, onerror=fail):
+            for name in names:
+                if name.startswith(".trackhound-") or Path(name).suffix.lower() not in self.extensions:
                     continue
-                ext = Path(filename).suffix.lower()
-                if ext in self.extensions:
-                    files.append(os.path.join(root, filename))
-
+                path = Path(root) / name
+                resolved = path.resolve(strict=True)
+                if resolved.is_relative_to(root_path) and resolved.is_file():
+                    files.append(str(path))
         return sorted(files)
 
-    async def process_file(
-        self,
-        file_path: str,
-        base_path: str,
-        media_type: str,
-        user_id: int,
-        db: AsyncSession,
-    ) -> Optional[MediaFile]:
-        """Process a single media file."""
+    async def process_file(self, file_path, base_path, media_type, user_id, db, *, incremental=True):
+        """Roll back only the current file when a probe or database write fails."""
         try:
             async with db.begin_nested():
-                return await self._process_file(file_path, base_path, media_type, user_id, db)
-        except Exception as e:
-            logger.error("Error processing file %s: %s", file_path, e)
-            await scan_state_manager.append_error(user_id, f"{file_path}: {str(e)}")
+                return await self._process_file(file_path, base_path, media_type, user_id, db, incremental)
+        except Exception as error:
+            logger.error("Error processing file %s: %s", file_path, error)
+            await scan_state_manager.append_error(user_id, f"{file_path}: {error}")
             return None
 
-    async def _process_file(self, file_path, base_path, media_type, user_id, db):
-        is_movie = media_type == "movie"
-        is_anime = media_type == "anime"
-
-        # Check if file already exists in database
-        result = await db.execute(
-            select(MediaFile).where(
-                MediaFile.file_path == file_path,
-                MediaFile.user_id == user_id,
-            )
-        )
-        existing = result.scalar_one_or_none()
-
-        # Get file stats
-        stat = os.stat(file_path)
-        file_mtime = datetime.fromtimestamp(stat.st_mtime)
-
-        # Skip if file hasn't changed (incremental scan)
-        if existing and existing.last_modified >= file_mtime:
+    async def _process_file(self, file_path, base_path, media_type, user_id, db, incremental):
+        existing = await db.scalar(select(MediaFile).where(MediaFile.file_path == file_path, MediaFile.user_id == user_id))
+        before = await asyncio.to_thread(os.stat, file_path)
+        modified = datetime.fromtimestamp(before.st_mtime)
+        if incremental and existing and existing.last_modified == modified and existing.file_size == before.st_size:
             return existing
 
-        # Analyze audio tracks
-        audio_info = require_successful_analysis(self.analyzer.analyze(file_path))
+        audio = require_successful_analysis(await asyncio.to_thread(self.analyzer.analyze, file_path))
+        after = await asyncio.to_thread(os.stat, file_path)
+        if (before.st_ino, before.st_size, before.st_mtime_ns) != (after.st_ino, after.st_size, after.st_mtime_ns):
+            raise ValueError("File changed during analysis; retry the scan when external writes finish.")
 
-        # Determine title and metadata based on media type
-        if is_movie:
-            show_title = parse_movie_title(file_path, base_path)
-            show_info = {"show": show_title, "season": None, "episode": None}
-        else:
-            show_info = parse_show_info(file_path, base_path)
-            show_title = show_info.get("show")
-
-        # Try to get metadata from Plex first
-        plex_metadata = None
+        base_type = "movie" if media_type == "movie" else "tv"
+        info = ({"show": parse_movie_title(file_path, base_path), "season": None, "episode": None}
+                if base_type == "movie" else parse_show_info(file_path, base_path))
+        metadata = None
         if self.plex_connector:
-            plex_metadata = self.plex_connector.sync_show_metadata(
-                file_path=file_path,
-                title_from_path=show_title,
-            )
+            try:
+                metadata = await asyncio.to_thread(self.plex_connector.sync_show_metadata, file_path=file_path, title_from_path=info["show"])
+            except Exception as error:
+                logger.warning("Plex enrichment disabled for this scan (%s)", type(error).__name__)
+                self.plex_connector = None
+                self.plex_failed = True
+                await scan_state_manager.append_warning(user_id, "Plex metadata is unavailable. Local scanning continues; check Plex server access or sign in again before the next scan.")
 
-        # Determine final title and anime status
-        if plex_metadata:
-            show_title = plex_metadata["title"]
-            plex_is_anime = plex_metadata["is_anime"]
-            anime_source = "plex_genre" if plex_is_anime else None
-            plex_rating_key = plex_metadata.get("plex_rating_key")
-            thumb_url = plex_metadata.get("thumb_url")
-            # If Plex says it's anime and we're in a TV folder, upgrade to anime
-            if plex_is_anime and media_type == "tv":
-                is_anime = True
-        else:
-            anime_source = "folder" if is_anime else None
-            plex_rating_key = None
-            thumb_url = None
+        title = metadata.get("title") if metadata else info["show"]
+        rating_key = metadata.get("plex_rating_key") if metadata else None
+        show = await db.scalar(select(Show).where(Show.id == existing.show_id, Show.user_id == user_id)) if existing and existing.show_id else None
+        if not show and rating_key:
+            show = await db.scalar(select(Show).where(Show.plex_rating_key == rating_key, Show.user_id == user_id).order_by(Show.id).limit(1))
+        if not show and title:
+            show = await db.scalar(select(Show).where(Show.user_id == user_id, Show.title.in_([title, info["show"]]),
+                                                     Show.base_media_type == base_type).order_by(Show.id).limit(1))
 
-        # Automatically fix default audio for non-anime content when possible
-        audio_info = require_successful_analysis(
-            self._auto_fix_default_track(
-                file_path=file_path, audio_info=audio_info, is_anime=is_anime,
-            )
-        )
+        # An anime location forces anime; other locations allow automatic hints.
+        # Manual positive and negative overrides win, including before auto-fix.
+        folder_hint = any(keyword in str(Path(file_path).parent).lower() for keyword in self.anime_detection.anime_folder_keywords)
+        plex_hint = bool(self.anime_detection.use_plex_genres and metadata and metadata.get("is_anime"))
+        is_anime = media_type == "anime" or folder_hint or plex_hint
+        source = "location" if media_type == "anime" else "folder" if folder_hint else "plex_genre" if plex_hint else None
+        if show and show.anime_source == "manual":
+            is_anime, source, base_type = show.is_anime, "manual", show.base_media_type
+        elif show and self.plex_failed and self.anime_detection.use_plex_genres and show.anime_source == "plex_genre" and not is_anime:
+            is_anime, source = show.is_anime, "plex_genre"
 
-        # Find or create show
-        show = None
+        if title and not show:
+            show = Show(user_id=user_id, title=title)
+            db.add(show)
+        if show:
+            classify_show(show, is_anime, source, base_type)
+            if metadata:
+                show.title = title
+                show.plex_rating_key = rating_key
+                show.thumb_url = metadata.get("thumb_url")
+            await db.flush()
+
+        audio = require_successful_analysis(await asyncio.to_thread(self._auto_fix_default_track, file_path, audio, is_anime))
+        after = await asyncio.to_thread(os.stat, file_path)
         season = None
-
-        if show_title:
-            # First try to find by Plex rating key
-            if plex_rating_key:
-                result = await db.execute(
-                    select(Show).where(
-                        Show.plex_rating_key == plex_rating_key,
-                        Show.user_id == user_id,
-                    )
-                )
-                show = result.scalar_one_or_none()
-
-            # Then try by title
-            if not show:
-                result = await db.execute(
-                    select(Show).where(
-                        Show.title == show_title, Show.user_id == user_id
-                    )
-                )
-                show = result.scalar_one_or_none()
-
-            # Check path-based title (handles English folder names)
-            if (
-                not show
-                and show_info.get("show")
-                and show_info["show"] != show_title
-            ):
-                result = await db.execute(
-                    select(Show).where(
-                        Show.title == show_info["show"], Show.user_id == user_id
-                    )
-                )
-                existing_show = result.scalar_one_or_none()
-                if existing_show:
-                    show = existing_show
-                    if plex_metadata:
-                        show.title = show_title
-                        show.plex_rating_key = plex_rating_key
-                        show.is_anime = is_anime
-                        show.anime_source = anime_source
-                        show.thumb_url = thumb_url
-
-            if not show:
-                show = Show(
-                    user_id=user_id,
-                    title=show_title,
-                    media_type=media_type,
-                    plex_rating_key=plex_rating_key,
-                    is_anime=is_anime,
-                    anime_source=anime_source,
-                    thumb_url=thumb_url,
-                )
-                db.add(show)
+        if show and base_type != "movie" and info.get("season") is not None:
+            season = await db.scalar(select(Season).where(Season.show_id == show.id, Season.season_number == info["season"]).order_by(Season.id).limit(1))
+            if not season:
+                season = Season(show_id=show.id, season_number=info["season"])
+                db.add(season)
                 await db.flush()
-            elif plex_metadata and not show.plex_rating_key:
-                show.plex_rating_key = plex_rating_key
-                show.is_anime = is_anime
-                show.anime_source = anime_source
-                if thumb_url:
-                    show.thumb_url = thumb_url
 
-            # Find or create season (TV/anime only)
-            if not is_movie and show_info.get("season"):
-                result = await db.execute(
-                    select(Season).where(
-                        Season.show_id == show.id,
-                        Season.season_number == show_info["season"],
-                    )
-                )
-                season = result.scalar_one_or_none()
-
-                if not season:
-                    season = Season(
-                        show_id=show.id,
-                        season_number=show_info["season"],
-                    )
-                    db.add(season)
-                    await db.flush()
-
-        # Create or update media file
+        media_file = existing or MediaFile(user_id=user_id, file_path=file_path)
         if existing:
-            media_file = existing
-            from app.models.entities import AudioTrack
-            from sqlalchemy import delete
-
-            await db.execute(
-                delete(AudioTrack).where(AudioTrack.media_file_id == media_file.id)
-            )
+            await db.execute(delete(AudioTrack).where(AudioTrack.media_file_id == existing.id))
         else:
-            media_file = MediaFile(user_id=user_id, file_path=file_path)
             db.add(media_file)
-
-        # Update media file info
-        media_file.filename = os.path.basename(file_path)
+        media_file.filename = Path(file_path).name
         media_file.show_id = show.id if show else None
         media_file.season_id = season.id if season else None
-        media_file.episode_number = (
-            show_info.get("episode") if not is_movie else None
-        )
-        media_file.file_size = stat.st_size
-        media_file.container_format = audio_info.get("container")
-        media_file.duration_ms = audio_info.get("duration_ms")
+        media_file.episode_number = info.get("episode") if base_type != "movie" else None
+        media_file.file_size = after.st_size
+        media_file.container_format = audio.get("container")
+        media_file.duration_ms = audio.get("duration_ms")
         media_file.last_scanned = datetime.now(timezone.utc).replace(tzinfo=None)
-        media_file.last_modified = file_mtime
-
-        await db.flush()
-
-        # Add audio tracks
-        from app.models.entities import AudioTrack
-
-        for track_info in audio_info.get("audio_tracks", []):
-            track = AudioTrack(
-                media_file_id=media_file.id,
-                track_index=track_info.get("index", 0),
-                language=track_info.get("language"),
-                language_raw=track_info.get("language_raw"),
-                codec=track_info.get("codec"),
-                channels=track_info.get("channels"),
-                channel_layout=track_info.get("channel_layout"),
-                bitrate=track_info.get("bitrate"),
-                is_default=track_info.get("is_default", False),
-                is_forced=track_info.get("is_forced", False),
-                title=track_info.get("title"),
-            )
-            db.add(track)
-
-        await db.flush()
-
-        # Evaluate preferences and set issues
-        final_is_anime = show.is_anime if show else is_anime
-        issues = self.preference_engine.evaluate(
-            audio_info.get("audio_tracks", []),
-            is_anime=final_is_anime,
-        )
-
-        media_file.has_issues = len(issues) > 0
+        media_file.last_modified = datetime.fromtimestamp(after.st_mtime)
+        issues = self.preference_engine.evaluate(audio.get("audio_tracks", []), is_anime=is_anime)
+        media_file.has_issues = bool(issues)
         media_file.issue_details = "; ".join(issues) if issues else None
-
+        await db.flush()
+        for track in audio.get("audio_tracks", []):
+            db.add(AudioTrack(
+                media_file_id=media_file.id, track_index=track.get("index", 0),
+                is_default=track.get("is_default", False), is_forced=track.get("is_forced", False),
+                **{key: track.get(key) for key in ("language", "language_raw", "codec", "channels", "channel_layout", "bitrate", "title")},
+            ))
+        await db.flush()
         return media_file
 
 
+def _root_identity(root):
+    value = os.stat(root)
+    if not stat_module.S_ISDIR(value.st_mode):
+        raise ValueError(f"Scan location is not a directory: {root}")
+    return value.st_dev, value.st_ino
 
-async def _load_user_audio_preferences(db: AsyncSession, user_id: int) -> AudioPreferences:
-    """Load per-user audio preferences with safe defaults."""
-    result = await db.execute(
-        select(UserPreference).where(
-            UserPreference.user_id == user_id,
-            UserPreference.key == "audio_preferences",
-        )
-    )
-    pref = result.scalar_one_or_none()
-    if not pref or not pref.value:
-        return AudioPreferences()
 
+def _missing_paths(rows, roots):
+    """Only remove genuinely missing paths; ignored extensions remain indexed."""
+    for root, identity in roots.items():
+        if _root_identity(root) != identity:
+            raise ValueError(f"Location changed or was unmounted during scanning: {root}")
+    missing = []
+    for row in rows:
+        try:
+            os.stat(row.file_path)
+        except FileNotFoundError:
+            missing.append(row.id)
+        # Permission and other I/O errors abort cleanup, rather than implying deletion.
+    return missing
+
+
+async def _reconcile_missing_files(db, user_id, discovered, roots):
+    if not roots:
+        return 0
+    scope = or_(*(MediaFile.file_path.startswith(root.rstrip("/") + "/", autoescape=True) for root in roots))
+    rows = (await db.execute(select(MediaFile.id, MediaFile.file_path).where(MediaFile.user_id == user_id, scope))).all()
+    missing = await asyncio.to_thread(_missing_paths, [row for row in rows if row.file_path not in discovered], roots)
+    for start in range(0, len(missing), 500):
+        await db.execute(delete(MediaFile).where(MediaFile.user_id == user_id, MediaFile.id.in_(missing[start:start + 500])))
+    await db.execute(delete(Season).where(Season.show_id.in_(select(Show.id).where(Show.user_id == user_id)),
+                                         ~select(MediaFile.id).where(MediaFile.season_id == Season.id).exists()))
+    await db.execute(delete(Show).where(Show.user_id == user_id,
+                                       ~select(MediaFile.id).where(MediaFile.show_id == Show.id).exists(),
+                                       ~select(Season.id).where(Season.show_id == Show.id).exists()))
+    return len(missing)
+
+
+async def run_scan(locations, location_media_types, user_id, incremental=True, user_plex_token=None, plex_warning=None):
+    """Persist valid files, but reconcile only a complete, uncancelled local scan."""
+    await scan_state_manager.update_status(user_id, is_running=True, outcome="running", files_scanned=0,
+        files_total=0, files_removed=0, current_file=None, started_at=datetime.now(timezone.utc), finished_at=None,
+        errors=[], warnings=[], error_count=0, warning_count=0)
+    failed = False
     try:
-        parsed = AudioPreferencesSchema.model_validate_json(pref.value)
-    except Exception:
-        return AudioPreferences()
-
-    return AudioPreferences(
-        require_english_non_anime=parsed.require_english_non_anime,
-        require_japanese_anime=parsed.require_japanese_anime,
-        require_dual_audio_anime=parsed.require_dual_audio_anime,
-        check_default_track=parsed.check_default_track,
-        preferred_codecs=parsed.preferred_codecs,
-        auto_fix_english_default_non_anime=parsed.auto_fix_english_default_non_anime,
-    )
-
-
-async def run_scan(
-    locations: list[str],
-    location_media_types: dict[str, str],
-    user_id: int,
-    incremental: bool = True,
-    user_plex_token: Optional[str] = None,
-) -> None:
-    """Run a scan on the specified locations."""
-    await scan_state_manager.update_status(
-        user_id,
-        is_running=True,
-        files_scanned=0,
-        files_total=0,
-        current_file=None,
-        started_at=datetime.now(timezone.utc),
-        errors=[],
-    )
-
-    scanner = MediaScanner(plex_token=user_plex_token)
-
-    try:
-        # Discover all files first
-        all_files = []
-        for location in locations:
-            await scan_state_manager.update_status(user_id, current_location=location)
-            try:
-                files = scanner.discover_files(location)
-                media_type = location_media_types.get(location, "tv")
-                all_files.extend([(f, location, media_type) for f in files])
-            except Exception as e:
-                logger.error("Error discovering files in %s: %s", location, e)
-                await scan_state_manager.append_error(
-                    user_id, f"Error scanning {location}: {str(e)}"
-                )
-
-        await scan_state_manager.update_status(user_id, files_total=len(all_files))
-
-        # Process files
+        if plex_warning:
+            await scan_state_manager.append_warning(user_id, plex_warning)
         async with async_session_maker() as db:
-            audio_preferences = await _load_user_audio_preferences(db, user_id)
-            scanner = MediaScanner(
-                plex_token=user_plex_token,
-                audio_preferences=audio_preferences,
-            )
-
-            for i, (file_path, base_path, media_type) in enumerate(all_files):
+            settings = await load_user_settings(db, user_id)
+            preferences = AudioPreferences(**settings.audio_preferences.model_dump(exclude={"audio_track_keep_languages"}))
+            scanner = MediaScanner(settings.file_extensions, user_plex_token, preferences, settings.anime_detection)
+            scanner.plex_failed = bool(plex_warning)
+            configured = (await db.scalars(select(ScanLocation).where(ScanLocation.user_id == user_id, ScanLocation.enabled == True))).all()
+            types = {location.path: location.media_type for location in configured}
+            types.update(location_media_types)
+            all_files, roots, complete = set(), {}, True
+            for location in locations:
                 if await scan_state_manager.is_cancel_requested(user_id):
                     break
-
-                await scan_state_manager.update_status(
-                    user_id,
-                    files_scanned=i + 1,
-                    current_file=os.path.basename(file_path),
-                )
-
-                await scanner.process_file(
-                    file_path, base_path, media_type, user_id, db
-                )
-
-                # Commit periodically
-                if (i + 1) % 50 == 0:
-                    await db.commit()
-
-            await db.commit()
-
-            # Update scan location stats
-            for location in locations:
-                result = await db.execute(
-                    select(ScanLocation).where(
-                        ScanLocation.path == location,
-                        ScanLocation.user_id == user_id,
-                    )
-                )
-                scan_loc = result.scalar_one_or_none()
-                if scan_loc:
-                    scan_loc.last_scanned = datetime.now(timezone.utc).replace(tzinfo=None)
-                    file_count = (
-                        await db.scalar(
-                            select(func.count(MediaFile.id)).where(
-                                MediaFile.file_path.like(f"{location}%"),
-                                MediaFile.user_id == user_id,
-                            )
-                        )
-                        or 0
-                    )
-                    scan_loc.file_count = file_count
-
-            await db.commit()
-
+                await scan_state_manager.update_status(user_id, current_location=location)
+                try:
+                    identity = await asyncio.to_thread(_root_identity, location)
+                    found = await asyncio.to_thread(scanner.discover_files, location)
+                    all_files.update(found)
+                    roots[location] = identity
+                except Exception as error:
+                    complete = False
+                    await scan_state_manager.append_error(user_id, f"Cannot fully read {location}: {error}")
+            await scan_state_manager.update_status(user_id, files_total=len(all_files))
+            if not roots and not await scan_state_manager.is_cancel_requested(user_id):
+                raise ValueError("No scan location could be read completely.")
+            for index, file_path in enumerate(sorted(all_files)):
+                if await scan_state_manager.is_cancel_requested(user_id):
+                    break
+                # The deepest configured enabled root determines classification,
+                # even when the user starts a scan from an overlapping parent.
+                candidates = [root for root in types if Path(file_path).is_relative_to(root)]
+                base_path = max(candidates, key=lambda root: len(Path(root).parts))
+                await scan_state_manager.update_status(user_id, current_location=base_path, current_file=Path(file_path).name)
+                result = await scanner.process_file(file_path, base_path, types[base_path], user_id, db, incremental=incremental)
+                complete = complete and result is not None
+                await db.commit()
+                await scan_state_manager.update_status(user_id, files_scanned=index + 1)
+            reconciled = complete and len(roots) == len(locations) and not await scan_state_manager.is_cancel_requested(user_id)
+            removed = await _reconcile_missing_files(db, user_id, all_files, roots) if reconciled else 0
+            # Counts reflect the rows that were actually saved, even after a partial scan.
+            current_locations = (await db.scalars(select(ScanLocation).where(ScanLocation.user_id == user_id))).all()
+            for location in current_locations:
+                location.file_count = await db.scalar(select(func.count(MediaFile.id)).where(MediaFile.user_id == user_id,
+                    MediaFile.file_path.startswith(location.path.rstrip("/") + "/", autoescape=True))) or 0
+                if reconciled and location.path in roots:
+                    location.last_scanned = datetime.now(timezone.utc).replace(tzinfo=None)
+            if reconciled and await scan_state_manager.is_cancel_requested(user_id):
+                await db.rollback()
+            else:
+                await db.commit()
+                await scan_state_manager.update_status(user_id, files_removed=removed)
+    except asyncio.CancelledError:
+        failed = True
+        raise
+    except Exception as error:
+        failed = True
+        logger.error("Scan failed for user %s: %s", user_id, error)
+        await scan_state_manager.append_error(user_id, f"Scan failed: {error}")
     finally:
-        await scan_state_manager.finish_scan(user_id)
+        await scan_state_manager.finish_scan(user_id, failed=failed)

--- a/backend/app/core/user_settings.py
+++ b/backend/app/core/user_settings.py
@@ -1,0 +1,32 @@
+"""Read the same validated preferences for the UI and background scans."""
+
+import json
+
+from pydantic import ValidationError
+from sqlalchemy import select
+
+from app.models.entities import UserPreference
+from app.models.schemas import AudioPreferences, AnimeDetectionSettings, UserSettingsResponse, normalize_file_extensions
+
+
+async def load_user_settings(db, user_id: int) -> UserSettingsResponse:
+    rows = await db.execute(select(UserPreference).where(UserPreference.user_id == user_id).order_by(UserPreference.id))
+    saved = {row.key: row.value for row in rows.scalars()}
+
+    def model(key, schema):
+        try:
+            return schema.model_validate_json(saved[key]) if key in saved else schema()
+        except ValidationError:
+            return schema()
+
+    extensions = UserSettingsResponse.model_fields["file_extensions"].get_default()
+    if "file_extensions" in saved:
+        try:
+            extensions = normalize_file_extensions(json.loads(saved["file_extensions"]))
+        except (ValueError, TypeError):
+            pass
+    return UserSettingsResponse(
+        audio_preferences=model("audio_preferences", AudioPreferences),
+        anime_detection=model("anime_detection", AnimeDetectionSettings),
+        file_extensions=extensions,
+    )

--- a/backend/app/migrations/versions/0003_classification.py
+++ b/backend/app/migrations/versions/0003_classification.py
@@ -1,0 +1,24 @@
+"""Remember the non-anime category and normalize inconsistent historical flags."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0003_classification"
+down_revision = "0002_ownership_constraints"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("shows", sa.Column("base_media_type", sa.String(20), nullable=True))
+    op.execute("UPDATE shows SET base_media_type = CASE WHEN media_type = 'movie' THEN 'movie' ELSE 'tv' END")
+    # The old unmark action changed only is_anime and left its prior source/type.
+    op.execute("UPDATE shows SET anime_source = 'manual' WHERE NOT is_anime AND (media_type = 'anime' OR anime_source IS NOT NULL)")
+    op.execute("UPDATE shows SET media_type = CASE WHEN is_anime THEN 'anime' ELSE base_media_type END")
+    op.execute("UPDATE shows SET anime_source = NULL WHERE NOT is_anime AND anime_source <> 'manual'")
+    with op.batch_alter_table("shows") as batch:
+        batch.alter_column("base_media_type", existing_type=sa.String(20), nullable=False)
+
+
+def downgrade():
+    raise RuntimeError("Restore the matching database backup to roll back classification changes.")

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -77,6 +77,7 @@ class Show(Base):
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     title: Mapped[str] = mapped_column(String(512), nullable=False)
+    base_media_type: Mapped[str] = mapped_column(String(20), default="tv", nullable=False)
     media_type: Mapped[str] = mapped_column(
         String(20), default="tv", nullable=False
     )  # tv, movie, anime

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -3,9 +3,10 @@
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+import re
+from typing import Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 MEDIA_ROOT = Path("/media").resolve()
@@ -140,6 +141,12 @@ class ScanStatus(BaseModel):
     current_file: Optional[str] = None
     started_at: Optional[datetime] = None
     errors: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    error_count: int = 0
+    warning_count: int = 0
+    files_removed: int = 0
+    finished_at: Optional[datetime] = None
+    outcome: Literal["idle", "running", "completed", "completed_with_errors", "cancelled", "failed"] = "idle"
 
 
 class ScanStartRequest(BaseModel):
@@ -243,6 +250,7 @@ class ShowResponse(BaseModel):
     id: int
     title: str
     media_type: str = "tv"
+    base_media_type: str = "tv"
     is_anime: bool
     anime_source: Optional[str] = None
     thumb_url: Optional[str] = None
@@ -264,9 +272,16 @@ class ShowDetailResponse(ShowResponse):
 class ShowUpdate(BaseModel):
     """Update show properties."""
 
-    media_type: Optional[str] = None
+    media_type: Optional[ScanMediaType] = None
     is_anime: Optional[bool] = None
-    anime_source: Optional[str] = None
+    anime_source: Optional[Literal["manual"]] = None
+
+    @model_validator(mode="after")
+    def consistent_classification(self):
+        if self.media_type is not None and self.is_anime is not None:
+            if self.is_anime != (self.media_type == ScanMediaType.ANIME):
+                raise ValueError("media_type and is_anime describe conflicting classifications")
+        return self
 
 
 class ShowListResponse(BaseModel):
@@ -300,6 +315,26 @@ class AnimeDetectionSettings(BaseModel):
     use_plex_genres: bool = True
     anime_folder_keywords: list[str] = ["anime", "animation"]
 
+    @field_validator("anime_folder_keywords")
+    @classmethod
+    def normalize_keywords(cls, keywords):
+        return list(dict.fromkeys(keyword.strip().lower() for keyword in keywords if keyword.strip()))
+
+
+def normalize_file_extensions(extensions):
+    if not isinstance(extensions, list) or not extensions:
+        raise ValueError("Choose at least one file extension")
+    normalized = []
+    for extension in extensions:
+        if not isinstance(extension, str):
+            raise ValueError("File extensions must be text")
+        extension = "." + extension.strip().lower().lstrip(".")
+        if not re.fullmatch(r"\.[a-z0-9]{1,10}", extension):
+            raise ValueError("Use file extensions such as .mkv or .mp4, without paths or wildcards")
+        if extension not in normalized:
+            normalized.append(extension)
+    return normalized
+
 
 class UserSettingsResponse(BaseModel):
     """User settings response."""
@@ -308,6 +343,8 @@ class UserSettingsResponse(BaseModel):
     anime_detection: AnimeDetectionSettings
     file_extensions: list[str] = [".mkv", ".mp4", ".avi", ".m4v"]
 
+    _normalize_extensions = field_validator("file_extensions")(normalize_file_extensions)
+
 
 class UserSettingsUpdate(BaseModel):
     """Update user settings."""
@@ -315,6 +352,11 @@ class UserSettingsUpdate(BaseModel):
     audio_preferences: Optional[AudioPreferences] = None
     anime_detection: Optional[AnimeDetectionSettings] = None
     file_extensions: Optional[list[str]] = None
+
+    @field_validator("file_extensions")
+    @classmethod
+    def validate_extensions(cls, extensions):
+        return normalize_file_extensions(extensions) if extensions is not None else None
 
 
 class UpdateDefaultAudioRequest(BaseModel):

--- a/backend/tests/test_database_migrations.py
+++ b/backend/tests/test_database_migrations.py
@@ -87,7 +87,7 @@ async def seed_legacy(engine, version):
 
 async def assert_upgraded(engine):
     async with engine.connect() as connection:
-        assert await connection.scalar(text("SELECT version_num FROM alembic_version")) == "0002_ownership_constraints"
+        assert await connection.scalar(text("SELECT version_num FROM alembic_version")) == "0003_classification"
         diffs = await connection.run_sync(lambda sync: compare_metadata(MigrationContext.configure(sync), Base.metadata))
         assert diffs == []
         if connection.dialect.name == "sqlite":
@@ -116,6 +116,22 @@ async def test_historical_upgrade_preserves_rows_and_matches_models(database, ve
 async def test_fresh_upgrade_matches_models(database):
     await upgrade_database(database)
     await assert_upgraded(database)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("media_type,is_anime,expected_base,expected_type", [
+    ("movie", True, "movie", "anime"),
+    ("anime", False, "tv", "tv"),
+])
+async def test_classification_upgrade_preserves_movie_origin_and_manual_unmark(database, media_type, is_anime, expected_base, expected_type):
+    await seed_legacy(database, "current")
+    async with database.begin() as connection:
+        await connection.execute(text("UPDATE shows SET media_type=:media_type, is_anime=:is_anime, anime_source=:source"),
+                                 {"media_type": media_type, "is_anime": is_anime, "source": "manual" if is_anime else "folder"})
+    await upgrade_database(database)
+    async with database.connect() as connection:
+        row = (await connection.execute(text("SELECT base_media_type, media_type, is_anime, anime_source FROM shows"))).one()
+        assert tuple(row) == (expected_base, expected_type, is_anime, "manual")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_scan_state.py
+++ b/backend/tests/test_scan_state.py
@@ -61,6 +61,21 @@ class ScanStateManagerTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(await self.manager.is_cancel_requested(user_id=1))
         self.assertFalse(await self.manager.is_cancel_requested(user_id=2))
 
+    async def test_completion_keeps_bounded_errors_and_total_count(self) -> None:
+        await self.manager.start_scan(user_id=1)
+        for index in range(60):
+            await self.manager.append_error(1, f"File {index} failed")
+        completed = await self.manager.finish_scan(1)
+        self.assertEqual(completed.outcome, "completed_with_errors")
+        self.assertEqual(completed.error_count, 60)
+        self.assertEqual(len(completed.errors), 50)
+        self.assertIsNotNone(completed.finished_at)
+        self.assertEqual((await self.manager.get_status(1)).errors, completed.errors)
+        restarted = await self.manager.start_scan(1)
+        self.assertEqual(restarted.error_count, 0)
+        self.assertEqual(restarted.errors, [])
+        self.assertIsNone(restarted.finished_at)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_scanner_run_scan.py
+++ b/backend/tests/test_scanner_run_scan.py
@@ -1,77 +1,369 @@
-"""Tests for scanner run loop argument passing and happy-path status."""
+"""Exercise complete scans against a real database and isolated media directories."""
 
-import unittest
-from unittest.mock import AsyncMock, patch
+from datetime import datetime
+import asyncio
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+from threading import Event
+from fastapi import BackgroundTasks
 
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from plexapi.exceptions import Unauthorized
+from requests.exceptions import Timeout
+
+from app.api import media, settings as settings_api, scan as scan_api
+from app.core import scanner as scanning
 from app.core.scan_state import scan_state_manager
-from app.core.scanner import run_scan
+from app.models.engine import create_database_engine
+from app.models.entities import Base, User, UserPreference, ScanLocation, Show, Season, MediaFile, AudioTrack
+from app.models.schemas import UserSettingsUpdate, ShowUpdate, ScanStartRequest
+
+ENGLISH = {"container": "Matroska", "audio_tracks": [{"index": 0, "language": "en", "is_default": True}]}
+JAPANESE = {"container": "Matroska", "audio_tracks": [{"index": 0, "language": "ja", "is_default": True}]}
 
 
-class _FakeResult:
-    def scalar_one_or_none(self):
-        return None
+def write_media(root, relative="Show/Season 01/E01.mkv"):
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"media fixture; audio probes are mocked")
+    return path
 
 
-class _FakeSession:
-    async def execute(self, *args, **kwargs):
-        return _FakeResult()
-
-    async def scalar(self, *args, **kwargs):
-        return 0
-
-    async def commit(self):
-        return None
-
-
-class _FakeSessionContext:
-    async def __aenter__(self):
-        return _FakeSession()
-
-    async def __aexit__(self, exc_type, exc, tb):
-        return False
-
-
-class RunScanArgumentPassingTests(unittest.IsolatedAsyncioTestCase):
-    async def asyncSetUp(self) -> None:
-        await scan_state_manager.reset()
-
-    async def asyncTearDown(self) -> None:
-        await scan_state_manager.reset()
-
-    async def test_run_scan_single_file_calls_process_file_with_user_id_and_no_errors(
-        self,
-    ):
-        file_path = "/media/tv/Show/Season 01/E01.mkv"
-
-        with (
-            patch(
-                "app.core.scanner.MediaScanner.discover_files", return_value=[file_path]
-            ),
-            patch(
-                "app.core.scanner.MediaScanner.process_file", new_callable=AsyncMock
-            ) as process_file,
-            patch(
-                "app.core.scanner.async_session_maker",
-                return_value=_FakeSessionContext(),
-            ),
-        ):
-            await run_scan(
-                locations=["/media/tv"],
-                location_media_types={"/media/tv": "tv"},
-                user_id=42,
-                incremental=False,
-            )
-
-        process_file.assert_awaited_once()
-        process_file.assert_awaited_once_with(
-            file_path, "/media/tv", "tv", 42, unittest.mock.ANY
-        )
-
-        status = await scan_state_manager.get_status(42)
-        self.assertEqual(status.files_total, 1)
-        self.assertEqual(status.files_scanned, 1)
-        self.assertEqual(status.errors, [])
+@pytest_asyncio.fixture
+async def library(tmp_path, monkeypatch):
+    root = tmp_path / "media"
+    root.mkdir()
+    engine = create_database_engine(f"sqlite+aiosqlite:///{tmp_path / 'library.db'}")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+    async with sessions() as db:
+        user = User(plex_user_id="123", plex_username="owner", plex_token="test")
+        db.add(user)
+        await db.flush()
+        location = ScanLocation(user_id=user.id, path=str(root), label="Library", media_type="tv")
+        db.add(location)
+        db.add(UserPreference(user_id=user.id, key="anime_detection", value='{"anime_folder_keywords":[]}'))
+        await db.commit()
+    monkeypatch.setattr(scanning, "async_session_maker", sessions)
+    monkeypatch.setattr(scanning.AudioAnalyzer, "analyze", lambda *_: ENGLISH)
+    await scan_state_manager.reset()
+    yield SimpleNamespace(root=root, sessions=sessions, user=user, location=location)
+    await scan_state_manager.reset()
+    await engine.dispose()
 
 
-if __name__ == "__main__":
-    unittest.main()
+async def run(library, *, incremental=False, roots=None, token=None):
+    roots = roots or [str(library.root)]
+    async with library.sessions() as db:
+        locations = (await db.scalars(select(ScanLocation).where(ScanLocation.user_id == library.user.id, ScanLocation.path.in_(roots)))).all()
+    await scan_state_manager.start_scan(library.user.id)
+    await scanning.run_scan(roots, {location.path: location.media_type for location in locations}, library.user.id,
+                            incremental=incremental, user_plex_token=token)
+    return await scan_state_manager.get_status(library.user.id)
+
+
+async def files(library):
+    async with library.sessions() as db:
+        return (await db.scalars(select(MediaFile).where(MediaFile.user_id == library.user.id).order_by(MediaFile.id))).all()
+
+
+async def settings(library, **updates):
+    async with library.sessions() as db:
+        result = await settings_api.update_settings(UserSettingsUpdate(**updates), library.user, db)
+        await db.commit()
+        return result
+
+
+@pytest.mark.asyncio
+async def test_full_scan_reanalyzes_unchanged_files_but_incremental_scan_skips(library):
+    write_media(library.root)
+    first = await run(library)
+    assert first.outcome == "completed"
+    before = (await files(library))[0]
+    with patch.object(scanning.AudioAnalyzer, "analyze", return_value=JAPANESE) as analyze:
+        await run(library, incremental=True)
+        analyze.assert_not_called()
+        assert (await files(library))[0].last_scanned == before.last_scanned
+        await run(library, incremental=False)
+        analyze.assert_called_once()
+    after = (await files(library))[0]
+    assert after.last_scanned > before.last_scanned
+    assert "Missing English" in after.issue_details
+    async with library.sessions() as db:
+        assert await db.scalar(select(AudioTrack.language)) == "ja"
+
+
+@pytest.mark.asyncio
+async def test_size_change_is_detected_even_when_mtime_is_unchanged(library):
+    source = write_media(library.root)
+    await run(library)
+    before = source.stat()
+    source.write_bytes(b"different size")
+    os.utime(source, ns=(before.st_atime_ns, before.st_mtime_ns))
+    with patch.object(scanning.AudioAnalyzer, "analyze", return_value=JAPANESE) as analyze:
+        await run(library, incremental=True)
+        analyze.assert_called_once()
+    assert (await files(library))[0].file_size == len(b"different size")
+
+
+@pytest.mark.asyncio
+async def test_saved_extensions_control_discovery_without_deleting_ignored_existing_files(library):
+    write_media(library.root)
+    await run(library)
+    mp4 = write_media(library.root, "Show/Season 01/E02.MP4")
+    saved = await settings(library, file_extensions=[" MP4 ", ".mp4"])
+    assert saved.file_extensions == [".mp4"]
+    with patch.object(scanning.AudioAnalyzer, "analyze", return_value=ENGLISH) as analyze:
+        status = await run(library)
+        analyze.assert_called_once_with(str(mp4))
+    assert status.files_total == 1
+    assert len(await files(library)) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [Timeout("offline"), Unauthorized("expired"), ValueError("No Plex server found")])
+async def test_plex_outage_does_not_skip_local_files_or_repeat_warnings(library, failure):
+    write_media(library.root)
+    write_media(library.root, "Show/Season 01/E02.mkv")
+    with patch.object(scanning, "PlexConnector") as plex:
+        plex.return_value.sync_show_metadata.side_effect = failure
+        status = await run(library, token="synthetic-test-token")
+        plex.return_value.sync_show_metadata.assert_called_once()
+    assert len(await files(library)) == 2
+    assert status.error_count == 0
+    assert status.warning_count == 1
+    assert "Local scanning continues" in status.warnings[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_genres", [True, False])
+async def test_saved_plex_genre_toggle_controls_classification(library, use_genres):
+    write_media(library.root)
+    await settings(library, anime_detection={"use_plex_genres": use_genres, "anime_folder_keywords": []})
+    with patch.object(scanning, "PlexConnector") as plex:
+        plex.return_value.sync_show_metadata.return_value = {"title": "Plex title", "is_anime": True, "plex_rating_key": "12"}
+        await run(library, token="synthetic-test-token")
+    async with library.sessions() as db:
+        show = await db.scalar(select(Show))
+        assert show.is_anime is use_genres
+        assert show.media_type == ("anime" if use_genres else "tv")
+        assert show.anime_source == ("plex_genre" if use_genres else None)
+
+
+@pytest.mark.asyncio
+async def test_saved_folder_keywords_and_explicit_anime_location(library):
+    write_media(library.root, "Cartoons/Season 01/E01.mkv")
+    await settings(library, anime_detection={"use_plex_genres": False, "anime_folder_keywords": [" CARTOONS "]})
+    await run(library)
+    async with library.sessions() as db:
+        assert (await db.scalar(select(Show))).anime_source == "folder"
+    await settings(library, anime_detection={"use_plex_genres": False, "anime_folder_keywords": []})
+    await run(library)
+    async with library.sessions() as db:
+        assert (await db.scalar(select(Show))).media_type == "tv"
+        location = await db.get(ScanLocation, library.location.id)
+        location.media_type = "anime"
+        await db.commit()
+    await run(library)
+    async with library.sessions() as db:
+        show = await db.scalar(select(Show))
+        assert show.media_type == "anime" and show.anime_source == "location"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("base_type", ["tv", "movie"])
+async def test_manual_classification_updates_analysis_stats_and_survives_rescans(library, base_type):
+    write_media(library.root)
+    async with library.sessions() as db:
+        (await db.get(ScanLocation, library.location.id)).media_type = base_type
+        await db.commit()
+    await run(library)
+    async with library.sessions() as db:
+        show = await db.scalar(select(Show))
+        response = await media.update_show(show.id, ShowUpdate(is_anime=True), library.user, db)
+        assert response.media_type == "anime" and response.base_media_type == base_type
+        assert response.issues_count == 1
+        stats = await media.get_dashboard_stats(library.user, db)
+        assert stats.anime_count == 1
+        assert stats.total_files_with_issues == 1
+        await db.commit()
+        show_id = show.id
+    with patch.object(scanning.MediaScanner, "_auto_fix_default_track", return_value=ENGLISH) as auto_fix:
+        await run(library)
+        assert auto_fix.call_args.args[-1] is True
+    async with library.sessions() as db:
+        response = await media.update_show(show_id, ShowUpdate(is_anime=False), library.user, db)
+        assert response.media_type == base_type
+        assert response.anime_source == "manual"
+        assert response.issues_count == 0
+        await db.commit()
+    with patch.object(scanning, "PlexConnector") as plex:
+        plex.return_value.sync_show_metadata.return_value = {"title": "Plex anime", "is_anime": True}
+        await run(library, token="synthetic-test-token")
+    async with library.sessions() as db:
+        show = await db.get(Show, show_id)
+        assert show.media_type == base_type and not show.is_anime
+        assert show.anime_source == "manual"
+
+
+@pytest.mark.asyncio
+async def test_overlapping_roots_scan_once_and_use_most_specific_classification(library):
+    child = library.root / "Nested"
+    source = write_media(child)
+    async with library.sessions() as db:
+        db.add(ScanLocation(user_id=library.user.id, path=str(child), label="Nested anime", media_type="anime"))
+        await db.commit()
+    with patch.object(scanning.AudioAnalyzer, "analyze", return_value=ENGLISH) as analyze:
+        status = await run(library, roots=[str(library.root), str(child)])
+        analyze.assert_called_once_with(str(source))
+    assert status.files_total == 1
+    async with library.sessions() as db:
+        assert (await db.scalar(select(Show))).media_type == "anime"
+        assert [location.file_count for location in (await db.scalars(select(ScanLocation))).all()] == [1, 1]
+    await run(library)  # Parent-only scan still respects the configured child type.
+    async with library.sessions() as db:
+        assert (await db.scalar(select(Show))).media_type == "anime"
+
+
+@pytest.mark.asyncio
+async def test_removed_and_moved_files_reconcile_tracks_and_empty_titles(library):
+    removed = write_media(library.root, "Removed/Season 01/E01.mkv")
+    moved = write_media(library.root, "Moved/Season 01/E01.mkv")
+    await run(library)
+    removed.unlink()
+    destination = write_media(library.root, "Destination/Season 01/E01.mkv")
+    moved.replace(destination)
+    status = await run(library)
+    assert status.files_removed == 2
+    assert [record.file_path for record in await files(library)] == [str(destination)]
+    async with library.sessions() as db:
+        assert await db.scalar(select(func.count(AudioTrack.id))) == 1
+        assert await db.scalar(select(func.count(Season.id))) == 1
+        assert await db.scalar(select(Show.title)) == "Destination"
+        assert (await db.get(ScanLocation, library.location.id)).file_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("problem", ["probe", "discovery", "cancel", "unmount"])
+async def test_partial_failed_and_cancelled_scans_never_reconcile(library, problem):
+    missing = write_media(library.root, "Missing/Season 01/E01.mkv")
+    write_media(library.root, "Present/Season 01/E01.mkv")
+    await run(library)
+    missing.unlink()
+    async with library.sessions() as db:
+        before = (await db.get(ScanLocation, library.location.id)).last_scanned
+    if problem == "probe":
+        with patch.object(scanning.AudioAnalyzer, "analyze", return_value={"error": "cannot analyze", "audio_tracks": []}):
+            status = await run(library)
+        assert status.outcome == "completed_with_errors"
+    elif problem == "discovery":
+        def unreadable(*args, onerror=None, **kwargs):
+            yield str(library.root), [], []
+            onerror(PermissionError("one directory is unreadable"))
+        with patch.object(scanning.os, "walk", side_effect=unreadable):
+            status = await run(library)
+        assert status.outcome == "failed"
+    elif problem == "cancel":
+        process = scanning.MediaScanner.process_file
+        async def cancel_after_file(self, *args, **kwargs):
+            result = await process(self, *args, **kwargs)
+            await scan_state_manager.cancel_scan(library.user.id)
+            return result
+        with patch.object(scanning.MediaScanner, "process_file", new=cancel_after_file):
+            status = await run(library)
+        assert status.outcome == "cancelled"
+    else:
+        with patch.object(scanning, "_root_identity", side_effect=[(1, 1), (2, 2)]):
+            status = await run(library)
+        assert status.outcome == "failed"
+    assert status.files_removed == 0
+    assert len(await files(library)) == 2
+    async with library.sessions() as db:
+        assert (await db.get(ScanLocation, library.location.id)).last_scanned == before
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_is_scoped_to_user_and_directory_boundary(library):
+    source = write_media(library.root)
+    await run(library)
+    async with library.sessions() as db:
+        other = User(plex_user_id="456", plex_username="other", plex_token="test")
+        db.add(other)
+        await db.flush()
+        db.add_all([
+            MediaFile(user_id=other.id, file_path=str(source), filename="same path", file_size=1, last_modified=datetime.now()),
+            MediaFile(user_id=library.user.id, file_path=str(library.root) + "-sibling/missing.mkv", filename="outside root", file_size=1, last_modified=datetime.now()),
+        ])
+        await db.commit()
+        other_id = other.id
+    source.unlink()
+    await run(library)
+    assert [record.filename for record in await files(library)] == ["outside root"]
+    async with library.sessions() as db:
+        assert await db.scalar(select(func.count(MediaFile.id)).where(MediaFile.user_id == other_id)) == 1
+
+
+@pytest.mark.parametrize("extensions", [[], ["../mkv"], ["*"], ["."], [".mkv/.mp4"]])
+def test_invalid_extensions_are_rejected(extensions):
+    with pytest.raises(ValueError):
+        UserSettingsUpdate(file_extensions=extensions)
+
+
+def test_conflicting_classification_is_rejected():
+    with pytest.raises(ValueError):
+        ShowUpdate(media_type="tv", is_anime=True)
+
+
+@pytest.mark.asyncio
+async def test_scan_can_be_cancelled_while_a_native_probe_is_running(library):
+    write_media(library.root)
+    started, release = Event(), Event()
+
+    def slow_probe(_):
+        started.set()
+        assert release.wait(timeout=5), "Probe blocked the event loop or cancellation"
+        return ENGLISH
+
+    with patch.object(scanning.AudioAnalyzer, "analyze", side_effect=slow_probe):
+        task = asyncio.create_task(run(library))
+        try:
+            assert await asyncio.to_thread(started.wait, 3)
+            cancelled = await asyncio.wait_for(scan_state_manager.cancel_scan(library.user.id), timeout=1)
+            assert cancelled and cancelled.is_running
+        finally:
+            release.set()
+            result = await task
+    assert result.outcome == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_unreadable_plex_token_still_schedules_a_local_scan(library):
+    write_media(library.root)
+    background = BackgroundTasks()
+    async with library.sessions() as db:
+        with patch.object(scan_api, "decrypt_value", side_effect=ValueError("wrong key")):
+            response = await scan_api.start_scan(ScanStartRequest(), background, library.user, db)
+    assert response.is_running
+    assert background.tasks[0].kwargs["user_plex_token"] is None
+    await background()
+    assert len(await files(library)) == 1
+    result = await scan_state_manager.get_status(library.user.id)
+    assert not result.is_running
+    assert result.warning_count == 1
+
+
+def test_empty_plex_library_is_loaded_only_once():
+    from app.core.plex_connector import PlexConnector
+    connector = PlexConnector("synthetic")
+    with patch.object(connector, "_get_server") as server:
+        server.return_value.library.sections.return_value = []
+        assert connector.sync_show_metadata("/media/Show/E01.mkv", "Show") is None
+        assert connector.sync_show_metadata("/media/Show/E02.mkv", "Show") is None
+        server.return_value.library.sections.assert_called_once()

--- a/docs/IMPLEMENTATION_PROGRESS.md
+++ b/docs/IMPLEMENTATION_PROGRESS.md
@@ -92,3 +92,18 @@ commands plus backup/upgrade/restore integration tests (#41). Historical fixture
 come from the actual initial and pre-ownership commits. PostgreSQL tests run
 against isolated databases in the CI service. See OPERATIONS.md for the required
 backup and rollback procedure. Later scan and UI issues are still in progress.
+
+## Scan follow-up: fix/scan-correctness
+
+This branch depends on the database PR #43. It honors full scans (#29), loads
+saved extensions and detection settings (#30), safely reconciles missing records
+(#31), and continues local scans when Plex fails (#32). Manual anime overrides
+now control analysis, filters, statistics, and scan-time edits consistently (#37),
+with a migration preserving the underlying movie/TV category. Scan work runs
+outside the request event loop, and status retains a bounded completion record
+for the UI follow-up (#38). See SCANNING.md for precedence and cleanup rules.
+
+Local validation: 118 backend tests passed, 11 integration cases require the CI
+PostgreSQL/native-tool environment. TypeScript and the production build passed.
+The remaining UI PR will cover draft settings saves (#34), production deep links
+(#36), completion/cache updates (#38), and frontend classification regressions.

--- a/docs/SCANNING.md
+++ b/docs/SCANNING.md
@@ -1,0 +1,57 @@
+# Scan behavior
+
+Each scan takes a snapshot of the user's saved audio preferences, file extensions,
+and anime detection settings. Extensions are case insensitive and normalized to
+values such as `.mkv`. Invalid or empty extension lists are rejected. An empty
+folder keyword list disables folder-based anime detection.
+
+Incremental scans skip a file only when both size and modification time match its
+stored values. Choose a full scan to reanalyze unchanged files after changing
+preferences, detection settings, or analyzer versions. Manual anime changes
+immediately reevaluate the cached audio tracks and issue counts.
+
+## Classification
+
+Manual anime marking or unmarking takes precedence over detection and scan-time
+automatic audio edits. Otherwise an Anime scan location forces anime, followed
+by matching folder keywords and enabled Plex genre detection. Other location
+types provide the underlying movie or TV category. The deepest enabled configured
+location wins when roots overlap, even if only its parent is selected for scanning.
+Files discovered through overlapping roots are processed once.
+
+`media_type` is the displayed/filterable category. `base_media_type` remembers
+movie or TV so unmarking anime restores that category. `is_anime` and
+`anime_source` are kept consistent with this choice. For historical anime rows
+without an identifiable original category, the migration uses TV. Historical
+negative manual choices are preserved where the prior flag/source reveals them.
+
+Plex enrichment is optional. A failed lookup disables enrichment for the rest of
+that scan and reports one warning; local path parsing and media analysis continue.
+An existing Plex genre classification is retained during an outage unless another
+classification rule overrides it. Unreadable stored tokens also allow local scans;
+sign in again or restore the matching encryption key before retrying Plex access.
+
+## Missing files and partial scans
+
+A scan removes database records for genuinely missing paths only after every
+selected root was fully enumerated, every discovered file was processed, and no
+cancellation was requested. Failed probes, permission errors, partial directory
+enumeration, and changed/unmounted roots prevent reconciliation. Existing files
+excluded by the current extension filter stay indexed.
+
+Cleanup is scoped to the scanning user and selected directories, including proper
+directory boundaries. Dependent audio rows and empty seasons/shows are removed.
+This cleanup never deletes a media file from disk. Location counts reflect saved
+rows; the successful-scan timestamp advances only after reconciliation commits.
+Moving a file is represented by removing its old missing row and indexing its new
+path. Successful per-file results remain available after an interrupted scan.
+
+The latest outcome, counts, and up to 50 errors and 50 warnings remain in scan
+status until the next scan or application restart. Native analysis, Plex calls,
+and directory discovery run outside the request event loop, allowing cancellation
+and status requests while those operations wait. Cancellation takes effect between
+operations; a native operation already running completes or reaches its timeout.
+
+Continue to use one application worker/container per media library. Job state and
+edit coordination are in-process; multiple workers and restart-resumable jobs need
+a shared job store and shared edit locks before they can be supported.

--- a/frontend/src/pages/ShowDetailPage.tsx
+++ b/frontend/src/pages/ShowDetailPage.tsx
@@ -104,7 +104,7 @@ export default function ShowDetailPage() {
       const response = await mediaApi.getSeason(showId, selectedSeason!)
       return response.data
     },
-    enabled: !!selectedSeason && !isNaN(showId) && show?.media_type !== 'movie',
+    enabled: selectedSeason !== null && !isNaN(showId) && show?.base_media_type !== 'movie',
   })
 
   const rescanFileMutation = useMutation({
@@ -138,7 +138,9 @@ export default function ShowDetailPage() {
     mutationFn: (isAnime: boolean) =>
       mediaApi.updateShow(showId, { is_anime: isAnime, anime_source: isAnime ? 'manual' : undefined }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['show', id] })
+      return Promise.all(['show', 'shows', 'stats', 'files', 'season'].map(
+        (key) => queryClient.invalidateQueries({ queryKey: [key] })
+      ))
     },
   })
 
@@ -162,7 +164,7 @@ export default function ShowDetailPage() {
   }
 
   const badge = MEDIA_TYPE_BADGE[show.media_type] || MEDIA_TYPE_BADGE.tv
-  const isMovie = show.media_type === 'movie'
+  const isMovie = show.base_media_type === 'movie'
 
   function renderSummary() {
     if (isMovie) {
@@ -209,8 +211,7 @@ export default function ShowDetailPage() {
             <RefreshCw className={`w-4 h-4 ${rescanShowMutation.isPending ? 'animate-spin' : ''}`} />
             Rescan Series
           </button>
-          {/* Only show anime toggle for TV shows */}
-          {show.media_type === 'tv' && (
+          {/* Preserve access to unmark after the title moves into the anime category. */}
             <button
               onClick={() => toggleAnimeMutation.mutate(!show.is_anime)}
               disabled={toggleAnimeMutation.isPending}
@@ -220,9 +221,8 @@ export default function ShowDetailPage() {
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
               }`}
             >
-              {show.is_anime ? 'Marked as Anime' : 'Mark as Anime'}
+              {show.is_anime ? 'Unmark as Anime' : 'Mark as Anime'}
             </button>
-          )}
         </div>
       </div>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -103,6 +103,7 @@ export interface Show {
   id: number
   title: string
   media_type: MediaType
+  base_media_type: 'tv' | 'movie'
   is_anime: boolean
   anime_source: string | null
   thumb_url: string | null


### PR DESCRIPTION
Scans previously skipped unchanged files even in full mode, ignored saved discovery/classification settings, depended on Plex availability, and retained missing files indefinitely. This PR fixes those behaviors and gives manual anime choices one consistent meaning across analysis, filters, statistics, and automatic edits.

- Load validated saved settings at scan start; normalize extensions and honor folder/Plex detection settings.
- Force reanalysis for full scans; deduplicate overlapping roots using the deepest enabled location's category.
- Isolate Plex failures and continue local analysis with one actionable warning.
- Reconcile genuinely missing database records only after complete, successful, uncancelled local discovery/processing. Protect partial/unmounted roots, ignored existing extensions, other users, and sibling paths; remove empty seasons/shows.
- Preserve the underlying movie/TV category in migration 0003. Manual positive and negative choices override detection before automatic audio edits, and immediately reevaluate cached track issues.
- Move blocking scan work off the request loop and retain bounded completion/error/warning status for the UI follow-up.

Validation: all 129 backend tests passed in CI, including PostgreSQL and native MKV integration. The frontend build and production container/Compose checks passed. [Passing CI run](https://github.com/TheSoloGreen/TrackHound/actions/runs/34276956266). Regression coverage includes failed/partial/cancelled/unmounted scans, moves, overlapping roots, full versus incremental scans, Plex failures, manual overrides, and historical classification migration. See docs/SCANNING.md for exact precedence and cleanup rules.

Dependency and merge order: #42, then #43, then this PR into `master`. This draft targets `fix/database-integrity` to keep its review focused. Back up the database with its matching encryption key before upgrading. No merge, deployment, or production database change has occurred.

Fixes #29, fixes #30, fixes #31, fixes #32. Backend/API fixes for #37 and status groundwork for #38; the next UI PR adds their frontend regression coverage.