### PR TITLE
Preserve settings drafts, serve deep links, and refresh completed scan results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: python -m pytest -q
 
   frontend-build:
-    name: Frontend build
+    name: Frontend tests and build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -67,6 +67,9 @@ jobs:
 
       - name: Install frontend dependencies
         run: npm ci
+
+      - name: Run frontend regression tests
+        run: npm test
 
       - name: Build frontend
         run: npm run build

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from fastapi.staticfiles import StaticFiles
+from app.static import SPAStaticFiles
 
 from app.config import get_settings
 from app.models.database import init_db
@@ -74,7 +74,7 @@ async def health_check():
 # Serve static frontend files in production
 static_path = Path(__file__).parent.parent / "static"
 if static_path.exists():
-    app.mount("/", StaticFiles(directory=str(static_path), html=True), name="static")
+    app.mount("/", SPAStaticFiles(directory=str(static_path), html=True), name="static")
 
 
 if __name__ == "__main__":

--- a/backend/app/static.py
+++ b/backend/app/static.py
@@ -1,0 +1,29 @@
+"""Serve client routes without disguising missing API endpoints or assets."""
+
+from pathlib import PurePosixPath
+
+from starlette.exceptions import HTTPException
+from starlette.staticfiles import StaticFiles
+
+
+class SPAStaticFiles(StaticFiles):
+    async def get_response(self, path, scope):
+        try:
+            response = await super().get_response(path, scope)
+            if response.status_code != 404:
+                return response
+        except HTTPException as error:
+            if error.status_code != 404:
+                raise
+
+        parts = PurePosixPath(path).parts
+        client_route = (
+            scope["method"] in {"GET", "HEAD"}
+            and not any(part.startswith(".") for part in parts)
+            and "\\" not in path
+            and (not parts or parts[0] not in {"api", "assets"})
+            and not PurePosixPath(path).suffix
+        )
+        if client_route:
+            return await super().get_response("index.html", scope)
+        raise HTTPException(status_code=404)

--- a/backend/tests/test_spa_routes.py
+++ b/backend/tests/test_spa_routes.py
@@ -1,0 +1,40 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.main import app as application
+from app.static import SPAStaticFiles
+
+
+@pytest.fixture
+def client(tmp_path):
+    (tmp_path / "index.html").write_text('<html><div id="root">TrackHound</div></html>')
+    (tmp_path / "assets").mkdir()
+    (tmp_path / "assets" / "app.js").write_text("window.trackhound = true;")
+    app = FastAPI()
+    app.router.routes.extend(application.router.routes)
+    app.mount("/", SPAStaticFiles(directory=tmp_path, html=True))
+    return TestClient(app)
+
+
+@pytest.mark.parametrize("path", ["/", "/library", "/library/12", "/files", "/settings"])
+@pytest.mark.parametrize("method", ["GET", "HEAD"])
+def test_direct_client_routes(client, path, method):
+    response = client.request(method, path)
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert ("TrackHound" in response.text) if method == "GET" else not response.content
+
+
+@pytest.mark.parametrize("path", ["/api/missing", "/api", "/assets/missing.js", "/assets/missing", "/missing.css", "/.env", "/%2E%2E/outside"])
+def test_missing_assets_api_and_traversal_do_not_return_spa(client, path):
+    response = client.get(path)
+    assert response.status_code == 404
+    assert "TrackHound" not in response.text
+
+
+def test_real_asset_api_and_method_responses_are_preserved(client):
+    assert client.get("/api/health").json()["status"] == "healthy"
+    asset = client.get("/assets/app.js")
+    assert asset.status_code == 200 and "window.trackhound" in asset.text
+    assert client.post("/library/12").status_code == 405

--- a/docs/IMPLEMENTATION_PROGRESS.md
+++ b/docs/IMPLEMENTATION_PROGRESS.md
@@ -1,109 +1,89 @@
 # TrackHound implementation checkpoint
 
-Branch: `fix/secure-media-editing`  
-Review baseline: `0ce4fa81fd8adc264fbf5b78457ad097939a91e2` on `master`
+Review baseline: `0ce4fa81fd8adc264fbf5b78457ad097939a91e2` on `master`.
+The implementation is split into dependent review branches. Nothing has been
+merged or deployed, and no production database or media has been changed.
 
-Draft review: [PR #42](https://github.com/TheSoloGreen/TrackHound/pull/42).
-Implementation is committed and saved on the branch; `master` is unchanged.
+TrackHound scans mounted media with MediaInfo, stores per-user titles, seasons,
+audio tracks and preference violations in SQLite or PostgreSQL, and uses Plex
+for sign-in and optional metadata. A React interface supports browsing, exports,
+rescans, default-audio changes, and MKV track removal. FastAPI serves the built UI.
 
-## Project overview
+## Review and merge order
 
-TrackHound scans mounted media files with MediaInfo, stores per-user shows,
-seasons, audio tracks, and preference violations in SQLite or PostgreSQL, and
-uses Plex for sign-in and metadata enrichment. Its React/TypeScript interface
-supports filtering, exports, rescans, default-audio changes, and MKV track removal.
-The application is packaged as a single FastAPI container serving the frontend.
+1. [PR #42](https://github.com/TheSoloGreen/TrackHound/pull/42),
+   `fix/secure-media-editing`: authorized access, explicit media-write capability,
+   recoverable MKV edits, language removal plans, and deployment checks.
+2. [PR #43](https://github.com/TheSoloGreen/TrackHound/pull/43),
+   `fix/database-integrity`: transactional historical upgrades, database-enforced
+   ownership and cascades, per-file savepoints, and verified backup/recovery.
+3. [PR #44](https://github.com/TheSoloGreen/TrackHound/pull/44),
+   `fix/scan-correctness`: scan settings/full rescans, Plex fallback, reconciliation,
+   classification consistency, and bounded completion status.
+4. `fix/ui-consistency`: draft preference saves, production deep links, shared
+   cache refresh, persistent scan summaries, and frontend regression tests.
 
-## First implementation batch
+Each follow-up targets the preceding branch to keep its diff focused. After its
+parent merges, retarget the next PR to `master` and check CI before merging.
+Preserve the parent commit ancestry when merging this stack; squash/rebase merges
+require updating dependent branches before proceeding. Historical branches outside
+this sequence have not been combined or removed.
 
-- Restrict Plex login and existing sessions to an administrator-configured account
-  allowlist. Blank configuration denies access. Reject known default and short
-  production keys, including direct use of the published image. Addresses #40.
-- Ship MKVToolNix and make all media writes an explicit instance opt-in. Report
-  live per-file tool, mount, and permission capabilities in the API and UI.
-  Apply the same policy to scan-time automatic edits. Addresses #28.
-- Fix PostgreSQL Compose environment strings and validate both deployment files
-  in CI. Addresses #26.
-- Use the saved keep-language policy for the UI's initial pruning selection.
-  Require the scan revision for explicit track indices and reject changed files.
-  Show the kept and removed tracks in confirmation. Addresses #35.
-- Preserve existing audio metadata on failed or unavailable analysis. Show scan
-  errors and refresh related cached file/show/stat data after file actions.
-  These are partial improvements for #38.
-- Serialize in-process edits, bound native subprocess durations, verify remux
-  output and source stability, protect prior backups, and restore the original
-  after replacement failures. Keep scan discovery away from temporary remux files.
-- Run manual editing and analysis off the request event loop. Broader scan worker
-  changes remain outstanding.
-- Add deployment, key, database-backup, and media-recovery notes in
-  [OPERATIONS.md](OPERATIONS.md), contributing to #41. Automated restore rehearsal
-  and key-rotation tooling remain future work.
+## Existing issue coverage
 
-No database migration, image deployment, or merge to `master` is part of this batch.
+| Issue | Implemented behavior | Review branch |
+| --- | --- | --- |
+| #26 | Valid Compose environment mappings; missing-key and render checks | secure-media-editing + database-integrity |
+| #27 | Transactional, versioned upgrades from actual historical schemas on SQLite/PostgreSQL | database-integrity |
+| #28 | Native MKV tools, opt-in writes, capability responses, backup/restore protection | secure-media-editing |
+| #29 | Full scans reanalyze unchanged files; dashboard exposes a Full scan option | scan-correctness + ui-consistency |
+| #30 | Saved extension and anime detection settings applied with documented precedence | scan-correctness |
+| #31 | Missing-record cleanup only after a complete uncancelled scan; user/root isolation | scan-correctness |
+| #32 | Plex timeout/auth/no-server failures fall back to local analysis with one warning | scan-correctness |
+| #33 | Per-user path uniqueness; a failed file does not poison the scan session | database-integrity |
+| #34 | Immediate local drafts, explicit serialized saves, response cache updates, retained later edits/errors | ui-consistency |
+| #35 | Saved keep-language plans, explicit overrides, exact confirmation and stale-revision rejection | secure-media-editing + ui-consistency tests |
+| #36 | SPA fallback for client routes; API and missing-asset behavior retained | ui-consistency |
+| #37 | Canonical anime category with manual precedence, restored movie/TV origin, refreshed issues/badges/stats | scan-correctness + ui-consistency |
+| #38 | Completion refreshes all library caches; persistent outcomes and bounded expandable messages | scan-correctness + ui-consistency |
+| #39 | Foreign keys on every SQLite connection, orphan cleanup, tested database cascades | database-integrity |
+| #40 | Plex account allowlist enforced on login and authenticated APIs; exposure guidance | secure-media-editing + database-integrity docs |
+| #41 | Consistent SQLite and PostgreSQL backups, rollback instructions, recovery integration tests | database-integrity |
+
+Issues remain open until the corresponding implementation is merged into the
+repository's default branch. Consult PR checks for the latest remote results.
 
 ## Validation
 
-- Original baseline: 38 backend tests passed; frontend production build passed.
-- Updated local suite: 80 passed, 1 skipped. The skipped test needs native
-  MKVToolNix executables, which are unavailable in the editing environment.
-- [CI run 34216958766](https://github.com/TheSoloGreen/TrackHound/actions/runs/34216958766)
-  passed on implementation commit `f6a8c1803f1c2e65de481d5b62513cca6872e134`:
-  **81 backend tests passed**, including the real MKV test. Frontend build and
-  container/Compose validation, secure startup, tool checks, and health smoke test
-  all passed. Image publication was correctly skipped for the draft PR.
-- Frontend: `npm run build` passed (TypeScript and Vite).
-- CI now installs ffmpeg, MediaInfo, and MKVToolNix for a real generated MKV test
-  that verifies language selection, default flags, video/subtitle retention, and
-  byte-for-byte preservation of the original backup.
-- CI also validates both Compose files, builds the production image, rejects
-  insecure direct image configuration, checks editing tools and read-only defaults,
-  and smoke-tests startup and health. Image publishing depends on these checks.
-- Local regression tests cover unauthorized Plex accounts and revoked sessions,
-  stale track choices, read-only paths, symlink escapes, saved language policies,
-  failed probes, successful API metadata refresh, concurrent edits, remux timeout,
-  existing backups, failed replacement, and failed automatic restoration.
+- PR #42 CI: 81 backend tests, real generated MKV editing, frontend build, both
+  Compose files, production startup/health and native-tool checks passed.
+- PR #43 CI: 98 backend tests passed, including historical PostgreSQL upgrades and
+  backup/upgrade/restore. Frontend and container checks also passed.
+- PR #44 local: 118 passed; 11 PostgreSQL/native-tool cases require CI.
+- Final UI branch local: 136 backend tests passed, 11 integration cases require
+  CI; 12 frontend regression tests and the TypeScript/production build passed.
+- CI installs the native tools and PostgreSQL service, runs frontend tests, builds
+  and smoke-tests the production container. Draft PRs do not publish images.
 
-Run from `backend`: `python -m pytest -q`. Run from `frontend`: `npm ci && npm run build`.
-Consult the PR checks for native-tool and container results; those cannot run in
-the local editing environment.
+Commands: `cd backend && python -m pytest -q`;
+`cd frontend && npm ci && npm test && npm run build`.
 
-## Remaining work, in suggested order
+## Before upgrading
 
-| Area | Work and existing issue |
-| --- | --- |
-| Database correctness | Introduce versioned migrations and upgrade tests (#27); scope file-path uniqueness per user and recover failed scan transactions (#33); enable and verify SQLite foreign keys (#39). |
-| Scan correctness | Honor full vs incremental scans (#29), saved extension/anime settings (#30), and reconcile deleted files only after successful discovery (#31). |
-| Scan resilience | Make Plex failures degrade to local metadata (#32); move synchronous scan probes, Plex calls, and filesystem work out of the async request loop; use durable job state and shared edit coordination before adding workers. |
-| Settings | Replace saves on every keystroke with a draft and explicit save or serialized partial updates (#34). |
-| Classification | Apply manual anime overrides consistently, including before scan-time auto-fixes (#37). |
-| Frontend consistency | Finish scan-completion cache invalidation and durable error reporting (#38); add SPA fallback for direct navigation to nested routes (#36). |
-| Operations | Rehearse database restore and build controlled key rotation (#41); document tested upgrade paths and pin release dependencies. |
+Follow [OPERATIONS.md](OPERATIONS.md): back up the database with its matching
+`ENCRYPTION_KEY`; retain valid keys; configure `ALLOWED_PLEX_USER_IDS`. Blank
+allowlists deny access. Editing stays disabled until explicitly enabled with
+writable media permissions. Schema rollback requires a matching backup and app
+version, rather than an unsafe destructive downgrade.
 
-Existing issues are at `https://github.com/TheSoloGreen/TrackHound/issues/<number>`.
-When resuming, inspect the branch and PR checks first, preserve completed work,
-then select the next bounded batch from this table.
+See [SCANNING.md](SCANNING.md) for exact detection, overlap, missing-file and
+cancellation rules. In Settings, edit preferences locally and choose **Save
+preferences**. Inputs remain editable during a save; newer changes need another
+save after the first finishes. Run a **Full scan** to apply new scan preferences
+to unchanged files. Location actions save individually.
 
-## Database follow-up: fix/database-integrity
-
-This branch depends on fix/secure-media-editing and adds the versioned historical
-upgrade path (#27), per-user file uniqueness and per-file savepoints (#33),
-SQLite foreign-key enforcement with orphan cleanup (#39), and consistent backup
-commands plus backup/upgrade/restore integration tests (#41). Historical fixtures
-come from the actual initial and pre-ownership commits. PostgreSQL tests run
-against isolated databases in the CI service. See OPERATIONS.md for the required
-backup and rollback procedure. Later scan and UI issues are still in progress.
-
-## Scan follow-up: fix/scan-correctness
-
-This branch depends on the database PR #43. It honors full scans (#29), loads
-saved extensions and detection settings (#30), safely reconciles missing records
-(#31), and continues local scans when Plex fails (#32). Manual anime overrides
-now control analysis, filters, statistics, and scan-time edits consistently (#37),
-with a migration preserving the underlying movie/TV category. Scan work runs
-outside the request event loop, and status retains a bounded completion record
-for the UI follow-up (#38). See SCANNING.md for precedence and cleanup rules.
-
-Local validation: 118 backend tests passed, 11 integration cases require the CI
-PostgreSQL/native-tool environment. TypeScript and the production build passed.
-The remaining UI PR will cover draft settings saves (#34), production deep links
-(#36), completion/cache updates (#38), and frontend classification regressions.
+Continue to use one worker/container per media library. Restart-resumable jobs,
+shared multi-worker edit locks, and controlled encryption-key rotation remain
+future improvements; they are outside the acceptance criteria of issues #26–41.
+The latest scan summary survives navigation and completion, but resets on the
+next scan or application restart.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,13 +19,87 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.18",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.3",
+        "@testing-library/user-event": "^14.6.7",
         "@types/react": "^19.2.10",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.2",
+        "jsdom": "^27.4.0",
         "tailwindcss": "^4.1.18",
         "typescript": "~5.9.3",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^4.1.11"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
@@ -261,6 +335,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -307,6 +391,146 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -751,6 +975,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1158,6 +1400,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
@@ -1456,6 +1705,104 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.7.tgz",
+      "integrity": "sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1500,6 +1847,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1549,6 +1914,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -1559,6 +2037,51 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -1587,6 +2110,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.1.0.tgz",
+      "integrity": "sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -1657,6 +2190,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1698,12 +2241,83 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1722,6 +2336,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1729,6 +2350,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -1740,6 +2371,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -1776,6 +2415,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
+      "integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1793,6 +2445,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1871,6 +2530,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2056,6 +2735,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -2068,6 +2784,23 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -2085,6 +2818,70 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2392,6 +3189,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2410,6 +3218,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -2430,6 +3245,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -2461,6 +3286,40 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2513,6 +3372,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -2520,6 +3395,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -2542,6 +3427,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -2591,6 +3484,30 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
@@ -2636,6 +3553,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2658,6 +3588,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2667,6 +3604,40 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
@@ -2699,6 +3670,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2714,6 +3702,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.12.tgz",
+      "integrity": "sha512-WylhSDKVeYnWXL3a+vKTaOxjnOeEGw938hImY8zoRWJjRRK/Jp1K+IihBzIONpUmW4e3WmXT6q5FW6vlESVZCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.12"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.12.tgz",
+      "integrity": "sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/typescript": {
@@ -2835,6 +3879,199 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,16 +6,22 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.3",
+    "@testing-library/user-event": "^14.6.7",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
+    "jsdom": "^27.4.0",
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.3",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^4.1.11"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.20",

--- a/frontend/src/api/cache.ts
+++ b/frontend/src/api/cache.ts
@@ -1,0 +1,8 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+// Prefixes also cover filtered lists, paginated results, and all open details.
+export function refreshLibrary(queryClient: QueryClient) {
+  return Promise.all([
+    'stats', 'shows', 'show', 'files', 'file', 'season', 'scanLocations', 'trackRemovalPlan',
+  ].map((key) => queryClient.invalidateQueries({ queryKey: [key] })))
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { NavLink, useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
+import { useScanStatus } from '../hooks/useScanStatus'
 import {
   LayoutDashboard,
   Library,
@@ -23,6 +24,7 @@ const navItems = [
 ]
 
 export default function Layout({ children }: LayoutProps) {
+  useScanStatus()
   const { user, logout } = useAuth()
   const navigate = useNavigate()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)

--- a/frontend/src/components/PreferencesForm.tsx
+++ b/frontend/src/components/PreferencesForm.tsx
@@ -1,0 +1,330 @@
+import { useRef, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
+import { settingsApi } from '../api/client'
+import type { UserSettings, MediaEditCapabilities } from '../types'
+
+const splitList = (text: string) => text.split(',').map((value) => value.trim()).filter(Boolean)
+
+export default function PreferencesForm({ initialSettings, editCapabilities }: {
+  initialSettings: UserSettings
+  editCapabilities?: MediaEditCapabilities
+}) {
+  const queryClient = useQueryClient()
+  const [settings, setSettings] = useState(initialSettings)
+  const [keywords, setKeywords] = useState(initialSettings.anime_detection.anime_folder_keywords.join(', '))
+  const [extensions, setExtensions] = useState(initialSettings.file_extensions.join(', '))
+  const revision = useRef(0)
+  const inFlight = useRef(false)
+  const [savedRevision, setSavedRevision] = useState(0)
+  const dirty = revision.current !== savedRevision
+
+  const editSettings = (changes: Partial<UserSettings>) => {
+    revision.current++
+    setSettings((previous) => ({ ...previous, ...changes }))
+  }
+  const save = useMutation({
+    mutationFn: async (submission: { settings: UserSettings; revision: number }) => {
+      await queryClient.cancelQueries({ queryKey: ['settings'] })
+      return (await settingsApi.update(submission.settings)).data as UserSettings
+    },
+    onSuccess: (response, submission) => {
+      queryClient.setQueryData(['settings'], response)
+      setSavedRevision(submission.revision)
+      // A response may normalize saved values, but cannot replace newer local edits.
+      if (revision.current === submission.revision) {
+        setSettings(response)
+        setKeywords(response.anime_detection.anime_folder_keywords.join(', '))
+        setExtensions(response.file_extensions.join(', '))
+      }
+      return queryClient.invalidateQueries({ queryKey: ['trackRemovalPlan'] })
+    },
+    onSettled: () => { inFlight.current = false },
+  })
+  const handleSave = (event: React.FormEvent) => {
+    event.preventDefault()
+    // Also guard same-tick submissions before React has disabled the button.
+    if (inFlight.current || !dirty) return
+    inFlight.current = true
+    save.mutate({ revision: revision.current, settings: {
+      ...settings,
+      anime_detection: { ...settings.anime_detection, anime_folder_keywords: splitList(keywords) },
+      file_extensions: splitList(extensions),
+    } })
+  }
+  const errorDetail = isAxiosError(save.error)
+    ? (save.error.response?.data?.errors?.join(' ') || save.error.response?.data?.detail)
+    : null
+
+  return (
+    <form onSubmit={handleSave} className="space-y-8" aria-label="Preferences">
+      {/* Audio Preferences */}
+      <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Audio Preferences
+        </h2>
+
+        <div className="space-y-4">
+          <label className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              checked={settings?.audio_preferences.require_english_non_anime ?? true}
+              onChange={(e) => {
+                if (!settings) return
+                editSettings({
+                  audio_preferences: {
+                    ...settings.audio_preferences,
+                    require_english_non_anime: e.target.checked,
+                  },
+                })
+              }}
+              className="w-4 h-4 text-orange-500 rounded"
+            />
+            <div>
+              <span className="font-medium text-gray-900 dark:text-white">
+                Require English audio for non-anime
+              </span>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Flag files missing English audio track
+              </p>
+            </div>
+          </label>
+
+          <label className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              checked={settings?.audio_preferences.require_japanese_anime ?? true}
+              onChange={(e) => {
+                if (!settings) return
+                editSettings({
+                  audio_preferences: {
+                    ...settings.audio_preferences,
+                    require_japanese_anime: e.target.checked,
+                  },
+                })
+              }}
+              className="w-4 h-4 text-orange-500 rounded"
+            />
+            <div>
+              <span className="font-medium text-gray-900 dark:text-white">
+                Require Japanese audio for anime
+              </span>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Flag anime files missing Japanese audio track
+              </p>
+            </div>
+          </label>
+
+          <label className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              checked={settings?.audio_preferences.require_dual_audio_anime ?? true}
+              onChange={(e) => {
+                if (!settings) return
+                editSettings({
+                  audio_preferences: {
+                    ...settings.audio_preferences,
+                    require_dual_audio_anime: e.target.checked,
+                  },
+                })
+              }}
+              className="w-4 h-4 text-orange-500 rounded"
+            />
+            <div>
+              <span className="font-medium text-gray-900 dark:text-white">
+                Require dual audio for anime
+              </span>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Flag anime files without both English and Japanese audio
+              </p>
+            </div>
+          </label>
+
+          <label className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              checked={settings?.audio_preferences.check_default_track ?? true}
+              onChange={(e) => {
+                if (!settings) return
+                editSettings({
+                  audio_preferences: {
+                    ...settings.audio_preferences,
+                    check_default_track: e.target.checked,
+                  },
+                })
+              }}
+              className="w-4 h-4 text-orange-500 rounded"
+            />
+            <div>
+              <span className="font-medium text-gray-900 dark:text-white">
+                Check default audio track
+              </span>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Flag if default track isn't the preferred language
+              </p>
+            </div>
+          </label>
+
+
+          <label className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              checked={settings?.audio_preferences.auto_fix_english_default_non_anime ?? false}
+              disabled={!editCapabilities?.set_default_audio && !settings.audio_preferences.auto_fix_english_default_non_anime}
+              onChange={(e) => {
+                if (!settings) return
+                editSettings({
+                  audio_preferences: {
+                    ...settings.audio_preferences,
+                    auto_fix_english_default_non_anime: e.target.checked,
+                  },
+                })
+              }}
+              className="w-4 h-4 text-orange-500 rounded"
+            />
+            <div>
+              <span className="font-medium text-gray-900 dark:text-white">
+                Auto-fix default to English (non-anime)
+              </span>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {editCapabilities?.default_audio_reason || 'Automatically set English as default during scans for writable non-anime MKV files.'}
+              </p>
+            </div>
+          </label>
+
+          <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 space-y-3">
+            <div>
+              <span className="font-medium text-gray-900 dark:text-white">
+                Default audio tracks to keep when removing tracks
+              </span>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Used by the removal tool when you do not manually override track selection. UND stays enabled by default because it can be mislabeled English.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-4">
+              {[
+                { value: 'en', label: 'English' },
+                { value: 'und', label: 'Undefined / UND' },
+                { value: 'ja', label: 'Japanese' },
+              ].map((option) => {
+                const keepLanguages = settings?.audio_preferences.audio_track_keep_languages ?? ['en', 'und']
+                const checked = keepLanguages.includes(option.value)
+                return (
+                  <label key={option.value} className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => {
+                        if (!settings) return
+                        const current = new Set(settings.audio_preferences.audio_track_keep_languages ?? ['en', 'und'])
+                        if (e.target.checked) {
+                          current.add(option.value)
+                        } else {
+                          current.delete(option.value)
+                        }
+                        editSettings({
+                          audio_preferences: {
+                            ...settings.audio_preferences,
+                            audio_track_keep_languages: [...current],
+                          },
+                        })
+                      }}
+                      className="w-4 h-4 text-orange-500 rounded"
+                    />
+                    {option.label}
+                  </label>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Anime Detection */}
+      <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Anime Detection
+        </h2>
+
+        <div className="space-y-4">
+          <label className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              checked={settings?.anime_detection.use_plex_genres ?? true}
+              onChange={(e) => {
+                if (!settings) return
+                editSettings({
+                  anime_detection: {
+                    ...settings.anime_detection,
+                    use_plex_genres: e.target.checked,
+                  },
+                })
+              }}
+              className="w-4 h-4 text-orange-500 rounded"
+            />
+            <div>
+              <span className="font-medium text-gray-900 dark:text-white">
+                Use Plex genres
+              </span>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Auto-detect anime from Plex genre tags
+              </p>
+            </div>
+          </label>
+
+          <div>
+            <label htmlFor="anime-keywords" className="block font-medium text-gray-900 dark:text-white mb-2">
+              Anime folder keywords
+            </label>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+              Paths containing these words will be marked as anime. Leave blank to disable folder detection.
+            </p>
+            <input
+              type="text"
+              id="anime-keywords"
+              value={keywords}
+              onChange={(e) => { revision.current++; setKeywords(e.target.value) }}
+              placeholder="anime, animation"
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* File Extensions */}
+      <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          File Extensions
+        </h2>
+
+        <div>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+            File extensions to scan (comma-separated)
+          </p>
+          <input
+            type="text"
+            id="file-extensions"
+            aria-label="File extensions"
+            value={extensions}
+            onChange={(e) => { revision.current++; setExtensions(e.target.value) }}
+            placeholder=".mkv, .mp4, .avi"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+          />
+        </div>
+      </section>
+      <div className="flex flex-wrap items-center gap-4">
+        <button type="submit" disabled={!dirty || save.isPending}
+          className="px-4 py-2 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white rounded-lg">
+          {save.isPending ? 'Saving…' : 'Save preferences'}
+        </button>
+        <p role="status" className="text-sm text-gray-600 dark:text-gray-400">
+          {save.isPending ? 'Saving preferences…' : dirty ? 'Unsaved changes' : save.isSuccess ? 'Preferences saved' : 'No unsaved changes'}
+        </p>
+        <p className="text-sm text-gray-600 dark:text-gray-400">Run a full scan after saving to apply changes to unchanged files.</p>
+      </div>
+      {save.isError && <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+        Could not save preferences. {typeof errorDetail === 'string' ? errorDetail : 'Please try again.'} Your edits have been kept.
+      </p>}
+    </form>
+  )
+}

--- a/frontend/src/components/ScanSummary.tsx
+++ b/frontend/src/components/ScanSummary.tsx
@@ -1,0 +1,38 @@
+import type { ScanStatus } from '../types'
+
+const labels: Record<ScanStatus['outcome'], string> = {
+  idle: '', running: 'Scan in progress', completed: 'Scan completed',
+  completed_with_errors: 'Scan completed with errors', cancelled: 'Scan cancelled', failed: 'Scan failed',
+}
+
+export default function ScanSummary({ status }: { status?: ScanStatus }) {
+  if (!status || status.outcome === 'idle') return null
+  return (
+    <section aria-label="Scan status" className="space-y-3 p-4 border border-orange-200 dark:border-orange-800 bg-orange-50 dark:bg-orange-900/20 rounded-xl">
+      <div role="status" aria-live="polite">
+        <h2 className="font-semibold text-gray-900 dark:text-white">{labels[status.outcome]}</h2>
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          {status.files_scanned} / {status.files_total} files processed · {status.files_removed} missing records removed
+        </p>
+        {status.is_running && <p className="text-sm break-words">{status.current_file || 'Discovering files…'}</p>}
+        {!status.is_running && status.finished_at && (
+          <p className="text-sm text-gray-600 dark:text-gray-400">Finished {new Date(status.finished_at).toLocaleString()}</p>
+        )}
+      </div>
+      {status.is_running && <progress aria-label="Scan progress" value={status.files_scanned} max={Math.max(status.files_total, 1)} className="w-full" />}
+      {(['errors', 'warnings'] as const).map((kind) => {
+        const count = kind === 'errors' ? status.error_count : status.warning_count
+        if (!count) return null
+        return (
+          <details key={kind} className="text-sm text-gray-800 dark:text-gray-200">
+            <summary className="cursor-pointer font-medium">{count} scan {kind}</summary>
+            <ul className="mt-2 space-y-1 break-words max-h-64 overflow-auto" aria-label={`Scan ${kind}`}>
+              {status[kind].slice(0, 50).map((message, index) => <li key={index}>{message}</li>)}
+            </ul>
+            {count > 50 && <p>Showing the first 50 {kind}.</p>}
+          </details>
+        )
+      })}
+    </section>
+  )
+}

--- a/frontend/src/hooks/useScanStatus.ts
+++ b/frontend/src/hooks/useScanStatus.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { scanApi } from '../api/client'
+import { refreshLibrary } from '../api/cache'
+import type { ScanStatus } from '../types'
+
+// Cache ownership keeps the completion marker scoped to the signed-in session.
+const refreshedCompletions = new WeakMap<object, string>()
+
+export function useScanStatus() {
+  const queryClient = useQueryClient()
+  const query = useQuery<ScanStatus>({
+    queryKey: ['scanStatus'],
+    queryFn: async () => (await scanApi.getStatus()).data,
+    refetchInterval: (query) => query.state.data?.is_running ? 2000 : 10000,
+  })
+  const status = query.data
+  const cache = queryClient.getQueryCache()
+  useEffect(() => {
+    if (!status || status.is_running || !status.finished_at) return
+    const marker = `${status.started_at}:${status.finished_at}`
+    // Use the query object, which is removed on logout, rather than a global user marker.
+    const scanQuery = cache.find({ queryKey: ['scanStatus'], exact: true })
+    if (!scanQuery || refreshedCompletions.get(scanQuery) === marker) return
+    refreshedCompletions.set(scanQuery, marker)
+    void refreshLibrary(queryClient)
+  }, [status, cache, queryClient])
+  return query
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,12 +6,14 @@ import {
   AlertTriangle,
   Play,
   Square,
-  RefreshCw,
   FileVideo,
   Sparkles,
 } from 'lucide-react'
 import { mediaApi, scanApi } from '../api/client'
 import type { DashboardStats, ScanStatus } from '../types'
+import { useScanStatus } from '../hooks/useScanStatus'
+import ScanSummary from '../components/ScanSummary'
+import { useState } from 'react'
 
 function StatCard({
   icon: Icon,
@@ -58,31 +60,19 @@ export default function DashboardPage() {
     },
   })
 
-  const { data: scanStatus } = useQuery<ScanStatus>({
-    queryKey: ['scanStatus'],
-    queryFn: async () => {
-      const response = await scanApi.getStatus()
-      return response.data
-    },
-    refetchInterval: (query) => {
-      return query.state.data?.is_running ? 2000 : 10000
-    },
-  })
+  const { data: scanStatus } = useScanStatus()
+  const [incremental, setIncremental] = useState(true)
 
   const startScan = useMutation({
-    mutationFn: () => scanApi.start({ incremental: true }),
+    mutationFn: () => scanApi.start({ incremental }),
     onMutate: async () => {
       await queryClient.cancelQueries({ queryKey: ['scanStatus'] })
       const previousStatus = queryClient.getQueryData<ScanStatus>(['scanStatus'])
 
       queryClient.setQueryData<ScanStatus>(['scanStatus'], {
-        is_running: true,
-        current_location: previousStatus?.current_location ?? null,
-        files_scanned: previousStatus?.files_scanned ?? 0,
-        files_total: previousStatus?.files_total ?? 0,
-        current_file: previousStatus?.current_file ?? 'Starting...',
-        started_at: previousStatus?.started_at ?? null,
-        errors: previousStatus?.errors ?? [],
+        is_running: true, outcome: 'running', current_location: null,
+        files_scanned: 0, files_total: 0, files_removed: 0, current_file: 'Starting…',
+        started_at: null, finished_at: null, errors: [], warnings: [], error_count: 0, warning_count: 0,
       })
 
       return { previousStatus }
@@ -121,7 +111,11 @@ export default function DashboardPage() {
             Overview of your media library audio tracks
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-2 items-center">
+          {!isScanning && <label className="text-sm text-gray-700 dark:text-gray-300">
+            <input type="checkbox" checked={!incremental} onChange={(event) => setIncremental(!event.target.checked)} className="mr-2" />
+            Full scan
+          </label>}
           {isScanning ? (
             <button
               onClick={() => cancelScan.mutate()}
@@ -144,35 +138,7 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      {/* Scan Status */}
-      {isScanning && scanStatus && (
-        <div className="bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 rounded-xl p-4">
-          <div className="flex items-center gap-3 mb-3">
-            <RefreshCw className="w-5 h-5 text-orange-600 dark:text-orange-400 animate-spin" />
-            <span className="font-medium text-orange-800 dark:text-orange-300">
-              Scan in progress...
-            </span>
-          </div>
-          <div className="space-y-2">
-            <div className="flex justify-between text-sm">
-              <span className="text-orange-700 dark:text-orange-400">
-                {scanStatus.current_file || 'Starting...'}
-              </span>
-              <span className="text-orange-700 dark:text-orange-400">
-                {scanStatus.files_scanned} / {scanStatus.files_total || '?'}
-              </span>
-            </div>
-            <div className="w-full bg-orange-200 dark:bg-orange-800 rounded-full h-2">
-              <div
-                className="bg-orange-500 h-2 rounded-full transition-all duration-300"
-                style={{
-                  width: `${scanStatus.files_total ? (scanStatus.files_scanned / scanStatus.files_total) * 100 : 0}%`,
-                }}
-              />
-            </div>
-          </div>
-        </div>
-      )}
+      <ScanSummary status={scanStatus} />
 
       {/* Error message */}
       {statsError && (
@@ -188,19 +154,6 @@ export default function DashboardPage() {
             {startScan.isError ? 'Failed to start scan.' : 'Failed to cancel scan.'} Please try again.
           </p>
         </div>
-      )}
-
-      {/* Stats Grid */}
-      {!!scanStatus?.errors.length && (
-        <details className="p-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg">
-          <summary className="cursor-pointer text-sm text-red-700 dark:text-red-400">
-            {scanStatus.errors.length} scan error{scanStatus.errors.length === 1 ? '' : 's'} reported
-          </summary>
-          <ul className="mt-2 space-y-1 text-sm text-red-700 dark:text-red-400 break-words">
-            {scanStatus.errors.slice(0, 50).map((message, index) => <li key={index}>{message}</li>)}
-          </ul>
-          {scanStatus.errors.length > 50 && <p className="mt-2 text-sm text-red-700 dark:text-red-400">Showing the first 50 errors.</p>}
-        </details>
       )}
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/frontend/src/pages/FilesPage.tsx
+++ b/frontend/src/pages/FilesPage.tsx
@@ -2,6 +2,7 @@ import { Fragment, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Search, AlertTriangle, FileVideo, ChevronDown, ChevronUp, Download, RefreshCw, Trash2 } from 'lucide-react'
 import { mediaApi } from '../api/client'
+import { refreshLibrary } from '../api/cache'
 import { useDebounce } from '../hooks/useDebounce'
 import type { MediaFile, PaginatedResponse, AudioTrackRemovalPlan } from '../types'
 import { isAxiosError } from 'axios'
@@ -38,9 +39,7 @@ export default function FilesPage() {
 
   const refreshMedia = () => {
     setTrackKeepSelections({})
-    return Promise.all(['files', 'stats', 'shows', 'show', 'season', 'trackRemovalPlan'].map(
-      (key) => queryClient.invalidateQueries({ queryKey: [key] })
-    ))
+    return refreshLibrary(queryClient)
   }
 
   const showActionError = (error: unknown) => {
@@ -140,11 +139,7 @@ export default function FilesPage() {
       await mediaApi.resetFiles()
       setExpandedFile(null)
       setPage(1)
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['files'] }),
-        queryClient.invalidateQueries({ queryKey: ['stats'] }),
-        queryClient.invalidateQueries({ queryKey: ['shows'] }),
-      ])
+      await refreshMedia()
     } catch {
       setActionError('Failed to reset scanned files. Please try again.')
     } finally {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import PreferencesForm from '../components/PreferencesForm'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Plus, Trash2, FolderOpen, ChevronRight, Folder } from 'lucide-react'
 import { settingsApi, scanApi, mediaApi } from '../api/client'
@@ -155,18 +156,6 @@ export default function SettingsPage() {
     },
   })
 
-  // Update settings mutation
-  const updateSettings = useMutation({
-    mutationFn: (data: Partial<UserSettings>) => settingsApi.update(data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['settings'] })
-      queryClient.invalidateQueries({ queryKey: ['trackRemovalPlan'] })
-    },
-    onError: () => {
-      queryClient.invalidateQueries({ queryKey: ['settings'] })
-    },
-  })
-
   // Location mutations
   const addLocation = useMutation({
     mutationFn: (data: { path: string; label: string; media_type: string }) =>
@@ -244,7 +233,9 @@ export default function SettingsPage() {
               >
                 <input
                   type="checkbox"
+                  aria-label={`Enable ${loc.label}`}
                   checked={loc.enabled}
+                  disabled={toggleLocation.isPending}
                   onChange={(e) => toggleLocation.mutate({ id: loc.id, enabled: e.target.checked })}
                   className="w-4 h-4 text-orange-500 rounded"
                 />
@@ -257,6 +248,8 @@ export default function SettingsPage() {
                 </span>
                 <span className="text-sm text-gray-500">{loc.file_count} files</span>
                 <button
+                  aria-label={`Delete ${loc.label}`}
+                  disabled={deleteLocation.isPending}
                   onClick={() => deleteLocation.mutate(loc.id)}
                   className="p-1 text-red-500 hover:text-red-700"
                 >
@@ -324,269 +317,8 @@ export default function SettingsPage() {
         )}
       </section>
 
-      {/* Audio Preferences */}
-      <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-          Audio Preferences
-        </h2>
-
-        <div className="space-y-4">
-          <label className="flex items-center gap-3">
-            <input
-              type="checkbox"
-              checked={settings?.audio_preferences.require_english_non_anime ?? true}
-              onChange={(e) => {
-                if (!settings) return
-                updateSettings.mutate({
-                  audio_preferences: {
-                    ...settings.audio_preferences,
-                    require_english_non_anime: e.target.checked,
-                  },
-                })
-              }}
-              className="w-4 h-4 text-orange-500 rounded"
-            />
-            <div>
-              <span className="font-medium text-gray-900 dark:text-white">
-                Require English audio for non-anime
-              </span>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Flag files missing English audio track
-              </p>
-            </div>
-          </label>
-
-          <label className="flex items-center gap-3">
-            <input
-              type="checkbox"
-              checked={settings?.audio_preferences.require_japanese_anime ?? true}
-              onChange={(e) => {
-                if (!settings) return
-                updateSettings.mutate({
-                  audio_preferences: {
-                    ...settings.audio_preferences,
-                    require_japanese_anime: e.target.checked,
-                  },
-                })
-              }}
-              className="w-4 h-4 text-orange-500 rounded"
-            />
-            <div>
-              <span className="font-medium text-gray-900 dark:text-white">
-                Require Japanese audio for anime
-              </span>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Flag anime files missing Japanese audio track
-              </p>
-            </div>
-          </label>
-
-          <label className="flex items-center gap-3">
-            <input
-              type="checkbox"
-              checked={settings?.audio_preferences.require_dual_audio_anime ?? true}
-              onChange={(e) => {
-                if (!settings) return
-                updateSettings.mutate({
-                  audio_preferences: {
-                    ...settings.audio_preferences,
-                    require_dual_audio_anime: e.target.checked,
-                  },
-                })
-              }}
-              className="w-4 h-4 text-orange-500 rounded"
-            />
-            <div>
-              <span className="font-medium text-gray-900 dark:text-white">
-                Require dual audio for anime
-              </span>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Flag anime files without both English and Japanese audio
-              </p>
-            </div>
-          </label>
-
-          <label className="flex items-center gap-3">
-            <input
-              type="checkbox"
-              checked={settings?.audio_preferences.check_default_track ?? true}
-              onChange={(e) => {
-                if (!settings) return
-                updateSettings.mutate({
-                  audio_preferences: {
-                    ...settings.audio_preferences,
-                    check_default_track: e.target.checked,
-                  },
-                })
-              }}
-              className="w-4 h-4 text-orange-500 rounded"
-            />
-            <div>
-              <span className="font-medium text-gray-900 dark:text-white">
-                Check default audio track
-              </span>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Flag if default track isn't the preferred language
-              </p>
-            </div>
-          </label>
-
-
-          <label className="flex items-center gap-3">
-            <input
-              type="checkbox"
-              checked={settings?.audio_preferences.auto_fix_english_default_non_anime ?? false}
-              disabled={!editCapabilities?.set_default_audio}
-              onChange={(e) => {
-                if (!settings) return
-                updateSettings.mutate({
-                  audio_preferences: {
-                    ...settings.audio_preferences,
-                    auto_fix_english_default_non_anime: e.target.checked,
-                  },
-                })
-              }}
-              className="w-4 h-4 text-orange-500 rounded"
-            />
-            <div>
-              <span className="font-medium text-gray-900 dark:text-white">
-                Auto-fix default to English (non-anime)
-              </span>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                {editCapabilities?.default_audio_reason || 'Automatically set English as default during scans for writable non-anime MKV files.'}
-              </p>
-            </div>
-          </label>
-
-          <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 space-y-3">
-            <div>
-              <span className="font-medium text-gray-900 dark:text-white">
-                Default audio tracks to keep when removing tracks
-              </span>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Used by the removal tool when you do not manually override track selection. UND stays enabled by default because it can be mislabeled English.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-4">
-              {[
-                { value: 'en', label: 'English' },
-                { value: 'und', label: 'Undefined / UND' },
-                { value: 'ja', label: 'Japanese' },
-              ].map((option) => {
-                const keepLanguages = settings?.audio_preferences.audio_track_keep_languages ?? ['en', 'und']
-                const checked = keepLanguages.includes(option.value)
-                return (
-                  <label key={option.value} className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={(e) => {
-                        if (!settings) return
-                        const current = new Set(settings.audio_preferences.audio_track_keep_languages ?? ['en', 'und'])
-                        if (e.target.checked) {
-                          current.add(option.value)
-                        } else {
-                          current.delete(option.value)
-                        }
-                        updateSettings.mutate({
-                          audio_preferences: {
-                            ...settings.audio_preferences,
-                            audio_track_keep_languages: [...current],
-                          },
-                        })
-                      }}
-                      className="w-4 h-4 text-orange-500 rounded"
-                    />
-                    {option.label}
-                  </label>
-                )
-              })}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Anime Detection */}
-      <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-          Anime Detection
-        </h2>
-
-        <div className="space-y-4">
-          <label className="flex items-center gap-3">
-            <input
-              type="checkbox"
-              checked={settings?.anime_detection.use_plex_genres ?? true}
-              onChange={(e) => {
-                if (!settings) return
-                updateSettings.mutate({
-                  anime_detection: {
-                    ...settings.anime_detection,
-                    use_plex_genres: e.target.checked,
-                  },
-                })
-              }}
-              className="w-4 h-4 text-orange-500 rounded"
-            />
-            <div>
-              <span className="font-medium text-gray-900 dark:text-white">
-                Use Plex genres
-              </span>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Auto-detect anime from Plex genre tags
-              </p>
-            </div>
-          </label>
-
-          <div>
-            <label className="block font-medium text-gray-900 dark:text-white mb-2">
-              Anime folder keywords
-            </label>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-              Paths containing these words will be marked as anime
-            </p>
-            <input
-              type="text"
-              value={settings?.anime_detection.anime_folder_keywords.join(', ') ?? ''}
-              onChange={(e) => {
-                if (!settings) return
-                updateSettings.mutate({
-                  anime_detection: {
-                    ...settings.anime_detection,
-                    anime_folder_keywords: e.target.value.split(',').map((s) => s.trim()).filter(Boolean),
-                  },
-                })
-              }}
-              placeholder="anime, animation"
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* File Extensions */}
-      <section className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-          File Extensions
-        </h2>
-
-        <div>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
-            File extensions to scan (comma-separated)
-          </p>
-          <input
-            type="text"
-            value={settings?.file_extensions.join(', ') ?? ''}
-            onChange={(e) =>
-              updateSettings.mutate({
-                file_extensions: e.target.value.split(',').map((s) => s.trim()).filter(Boolean),
-              })
-            }
-            placeholder=".mkv, .mp4, .avi"
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-          />
-        </div>
-      </section>
+      {settings ? <PreferencesForm initialSettings={settings} editCapabilities={editCapabilities} />
+        : <p role="alert">Could not load preferences. Refresh the page to try again.</p>}
     </div>
   )
 }

--- a/frontend/src/pages/ShowDetailPage.tsx
+++ b/frontend/src/pages/ShowDetailPage.tsx
@@ -2,6 +2,7 @@ import { useParams, Link, useLocation } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, AlertTriangle, RefreshCw } from 'lucide-react'
 import { mediaApi } from '../api/client'
+import { refreshLibrary } from '../api/cache'
 import type { ShowDetail, SeasonDetail, MediaFile, MediaType } from '../types'
 import { useState } from 'react'
 
@@ -111,12 +112,11 @@ export default function ShowDetailPage() {
     mutationFn: (fileId: number) => mediaApi.rescanFile(fileId),
     onSuccess: () => {
       setRescanError(null)
-      queryClient.invalidateQueries({ queryKey: ['show', id] })
-      queryClient.invalidateQueries({ queryKey: ['season', id, selectedSeason] })
-      queryClient.invalidateQueries({ queryKey: ['files'] })
+      return refreshLibrary(queryClient)
     },
     onError: () => {
       setRescanError('Failed to rescan file. Please confirm the file still exists and try again.')
+      void refreshLibrary(queryClient)
     },
   })
 
@@ -125,12 +125,11 @@ export default function ShowDetailPage() {
     mutationFn: () => mediaApi.rescanShow(showId),
     onSuccess: () => {
       setRescanError(null)
-      queryClient.invalidateQueries({ queryKey: ['show', id] })
-      queryClient.invalidateQueries({ queryKey: ['season', id, selectedSeason] })
-      queryClient.invalidateQueries({ queryKey: ['files'] })
+      return refreshLibrary(queryClient)
     },
     onError: () => {
       setRescanError('Failed to rescan series. Please confirm files still exist and try again.')
+      void refreshLibrary(queryClient)
     },
   })
 
@@ -138,10 +137,10 @@ export default function ShowDetailPage() {
     mutationFn: (isAnime: boolean) =>
       mediaApi.updateShow(showId, { is_anime: isAnime, anime_source: isAnime ? 'manual' : undefined }),
     onSuccess: () => {
-      return Promise.all(['show', 'shows', 'stats', 'files', 'season'].map(
-        (key) => queryClient.invalidateQueries({ queryKey: [key] })
-      ))
+      setRescanError(null)
+      return refreshLibrary(queryClient)
     },
+    onError: () => { setRescanError('Failed to update classification. Please try again.') },
   })
 
   if (isLoading) {
@@ -295,7 +294,7 @@ export default function ShowDetailPage() {
           {/* Episode List */}
           <div className="lg:col-span-2 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4">
             <h2 className="font-semibold text-gray-900 dark:text-white mb-4">
-              {selectedSeason ? `Season ${selectedSeason} Episodes` : 'Select a season'}
+              {selectedSeason !== null ? `Season ${selectedSeason} Episodes` : 'Select a season'}
             </h2>
             {seasonLoading ? (
               <div className="flex items-center justify-center py-8">

--- a/frontend/src/test/MediaActions.test.tsx
+++ b/frontend/src/test/MediaActions.test.tsx
@@ -1,0 +1,88 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { expect, it, vi } from 'vitest'
+import { mediaApi } from '../api/client'
+import ShowDetailPage from '../pages/ShowDetailPage'
+import FilesPage from '../pages/FilesPage'
+import { makeClient, mediaFile, renderWithClient } from './helpers'
+import type { ShowDetail } from '../types'
+
+it.each(['tv', 'movie'] as const)('marks and unmarks %s consistently and refreshes aggregates', async (base) => {
+  const client = makeClient()
+  const user = userEvent.setup()
+  let show: ShowDetail = { id: 1, title: 'A title', media_type: base, base_media_type: base,
+    is_anime: false, anime_source: null, thumb_url: null, season_count: 1, episode_count: 1,
+    file_count: 1, issues_count: 0, created_at: '', updated_at: '', media_files: [mediaFile],
+    seasons: [{ id: 1, season_number: 0, episode_count: 1, issues_count: 0 }] }
+  vi.spyOn(mediaApi, 'getShow').mockImplementation(async () => ({ data: show }) as Awaited<ReturnType<typeof mediaApi.getShow>>)
+  const update = vi.spyOn(mediaApi, 'updateShow').mockImplementation(async (_id, data) => {
+    show = { ...show, is_anime: !!data.is_anime, media_type: data.is_anime ? 'anime' : base,
+      anime_source: 'manual', issues_count: data.is_anime ? 1 : 0 }
+    return { data: show } as Awaited<ReturnType<typeof mediaApi.updateShow>>
+  })
+  vi.spyOn(mediaApi, 'getSeason').mockResolvedValue({ data: { ...show.seasons[0], media_files: [mediaFile] } } as Awaited<ReturnType<typeof mediaApi.getSeason>>)
+  const keys = [['stats'], ['shows', 'anime'], ['files'], ['season', '1', 0], ['scanLocations']]
+  keys.forEach((key) => client.setQueryData(key, { before: true }))
+  renderWithClient(<MemoryRouter initialEntries={['/library/1']}><Routes>
+    <Route path="/library/:id" element={<ShowDetailPage />} />
+  </Routes></MemoryRouter>, client)
+  await user.click(await screen.findByRole('button', { name: 'Mark as Anime' }))
+  expect(await screen.findByText('Anime', { selector: 'span' })).toBeVisible()
+  expect(screen.getByText('• 1 issue')).toBeVisible()
+  keys.forEach((key) => expect(client.getQueryState(key)?.isInvalidated).toBe(true))
+  if (base === 'movie') {
+    expect(screen.getByText('movie.mkv')).toBeVisible()
+    expect(screen.queryByRole('heading', { name: 'Seasons' })).not.toBeInTheDocument()
+  }
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Unmark as Anime' })).toBeEnabled())
+  await user.click(screen.getByRole('button', { name: 'Unmark as Anime' }))
+  expect(await screen.findByText(base === 'movie' ? 'Movie' : 'TV Show', { selector: 'span' })).toBeVisible()
+  expect(screen.queryByText('• 1 issue')).not.toBeInTheDocument()
+  expect(update).toHaveBeenCalledTimes(2)
+})
+
+it('uses the saved removal plan and sends an explicit manual override with an exact confirmation', async () => {
+  const client = makeClient()
+  const user = userEvent.setup()
+  vi.spyOn(mediaApi, 'getFiles').mockResolvedValue({ data: { items: [mediaFile], page: 1, pages: 1, total: 1, page_size: 25 } } as Awaited<ReturnType<typeof mediaApi.getFiles>>)
+  // The backend normalizes Japanese raw codes and missing/undefined languages.
+  vi.spyOn(mediaApi, 'getAudioTrackRemovalPlan').mockResolvedValue({ data: {
+    file_id: 1, last_scanned: mediaFile.last_scanned, keep_track_indices: [2, 3],
+  } } as Awaited<ReturnType<typeof mediaApi.getAudioTrackRemovalPlan>>)
+  const remove = vi.spyOn(mediaApi, 'removeAudioTracks').mockResolvedValue({ data: {} } as Awaited<ReturnType<typeof mediaApi.removeAudioTracks>>)
+  const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
+  const keys = [['stats'], ['shows'], ['show', '1'], ['season', '1', 1], ['file', 1], ['scanLocations']]
+  keys.forEach((key) => client.setQueryData(key, { before: true }))
+  renderWithClient(<FilesPage />, client)
+  await user.click(await screen.findByText('movie.mkv'))
+  const english = screen.getByRole('checkbox', { name: 'Keep #1 EN' })
+  const japanese = screen.getByRole('checkbox', { name: 'Keep #2 JA' })
+  const undefinedLanguage = screen.getByRole('checkbox', { name: 'Keep #3 UND' })
+  await waitFor(() => expect(japanese).toBeChecked())
+  expect(english).not.toBeChecked()
+  expect(undefinedLanguage).toBeChecked()
+  await user.click(english)
+  await user.click(japanese)
+  await user.click(screen.getByRole('button', { name: 'Remove Unchecked Tracks' }))
+  expect(confirm.mock.calls[0][0]).toContain('Keep: #1 EN, #3 UND\nRemove: #2 JA')
+  await waitFor(() => expect(remove).toHaveBeenCalledWith(1, {
+    keep_track_indices: [1, 3], keep_backup: true, expected_last_scanned: mediaFile.last_scanned,
+  }))
+  await waitFor(() => expect(client.getQueryState(['stats'])?.isInvalidated).toBe(true))
+  keys.forEach((key) => expect(client.getQueryState(key)?.isInvalidated).toBe(true))
+})
+
+it('refreshes detail and location counts after a library reset', async () => {
+  const client = makeClient()
+  vi.spyOn(mediaApi, 'getFiles').mockResolvedValue({ data: { items: [], page: 1, pages: 1, total: 0 } } as Awaited<ReturnType<typeof mediaApi.getFiles>>)
+  const reset = vi.spyOn(mediaApi, 'resetFiles').mockResolvedValue({ data: {} } as Awaited<ReturnType<typeof mediaApi.resetFiles>>)
+  vi.spyOn(window, 'confirm').mockReturnValue(true)
+  const keys = [['stats'], ['shows'], ['show', '1'], ['season', '1', 1], ['file', 1], ['scanLocations']]
+  keys.forEach((key) => client.setQueryData(key, { before: true }))
+  renderWithClient(<FilesPage />, client)
+  await userEvent.click(await screen.findByRole('button', { name: /Reset Scanned Files/i }))
+  await waitFor(() => expect(reset).toHaveBeenCalledTimes(1))
+  await waitFor(() => expect(client.getQueryState(['scanLocations'])?.isInvalidated).toBe(true))
+  keys.forEach((key) => expect(client.getQueryState(key)?.isInvalidated).toBe(true))
+})

--- a/frontend/src/test/PreferencesForm.test.tsx
+++ b/frontend/src/test/PreferencesForm.test.tsx
@@ -1,0 +1,62 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { settingsApi } from '../api/client'
+import PreferencesForm from '../components/PreferencesForm'
+import { deferred, makeClient, renderWithClient, settings } from './helpers'
+
+describe('preference saves', () => {
+  it('keeps rapid typing local, serializes saves, and retains edits made during a delayed response', async () => {
+    const first = deferred<Awaited<ReturnType<typeof settingsApi.update>>>()
+    const update = vi.spyOn(settingsApi, 'update').mockReturnValueOnce(first.promise)
+      .mockImplementation(async (data) => ({ data }) as Awaited<ReturnType<typeof settingsApi.update>>)
+    const user = userEvent.setup()
+    const client = makeClient()
+    client.setQueryData(['settings'], settings)
+    renderWithClient(<PreferencesForm initialSettings={settings} />, client)
+    const keywords = screen.getByLabelText('Anime folder keywords')
+    await user.clear(keywords)
+    await user.type(keywords, 'anime, animation, ')
+    await user.click(screen.getByRole('checkbox', { name: /Require English audio/ }))
+    await user.click(screen.getByRole('checkbox', { name: /Require Japanese audio/ }))
+    expect(keywords).toHaveValue('anime, animation, ')
+    expect(update).not.toHaveBeenCalled()
+    await user.click(screen.getByRole('button', { name: 'Save preferences' }))
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1))
+    const submitted = update.mock.calls[0][0]
+    expect(submitted).toMatchObject({ audio_preferences: { require_english_non_anime: false, require_japanese_anime: false } })
+    await user.type(keywords, 'newer draft')
+    fireEvent.submit(screen.getByRole('form', { name: 'Preferences' }))
+    expect(screen.getByRole('button', { name: 'Saving…' })).toBeDisabled()
+    expect(update).toHaveBeenCalledTimes(1)
+    await act(async () => first.resolve({ data: submitted } as Awaited<ReturnType<typeof settingsApi.update>>))
+    expect(keywords).toHaveValue('anime, animation, newer draft')
+    expect(client.getQueryData(['settings'])).toEqual(submitted)
+    await user.click(screen.getByRole('button', { name: 'Save preferences' }))
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Preferences saved'))
+    expect(update).toHaveBeenCalledTimes(2)
+    expect(update.mock.calls[1][0]).toMatchObject({ anime_detection: { anime_folder_keywords: ['anime', 'animation', 'newer draft'] } })
+  })
+
+  it('ignores an older query result after a newer save and retains failed edits for retry', async () => {
+    const client = makeClient()
+    const oldRead = deferred<typeof settings>()
+    const update = vi.spyOn(settingsApi, 'update').mockRejectedValueOnce(new Error('offline'))
+      .mockImplementation(async (data) => ({ data }) as Awaited<ReturnType<typeof settingsApi.update>>)
+    client.setQueryData(['settings'], settings)
+    // Simulate a GET already in flight when the user begins saving.
+    const oldRequest = client.fetchQuery({ queryKey: ['settings'], queryFn: () => oldRead.promise, staleTime: 0 }).catch(() => {})
+    const user = userEvent.setup()
+    renderWithClient(<PreferencesForm initialSettings={settings} />, client)
+    const extensions = screen.getByLabelText('File extensions')
+    await user.type(extensions, ', .mp4')
+    await user.click(screen.getByRole('button', { name: 'Save preferences' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Your edits have been kept')
+    expect(extensions).toHaveValue('.mkv, .mp4')
+    await user.click(screen.getByRole('button', { name: 'Save preferences' }))
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Preferences saved'))
+    await act(async () => { oldRead.resolve(settings); await oldRequest })
+    expect(client.getQueryData(['settings'])).toMatchObject({ file_extensions: ['.mkv', '.mp4'] })
+    expect(update).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/test/ScanStatus.test.tsx
+++ b/frontend/src/test/ScanStatus.test.tsx
@@ -1,0 +1,55 @@
+import { act, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { expect, it, vi } from 'vitest'
+import { scanApi } from '../api/client'
+import { useScanStatus } from '../hooks/useScanStatus'
+import ScanSummary from '../components/ScanSummary'
+import DashboardPage from '../pages/DashboardPage'
+import { mediaApi } from '../api/client'
+import { makeClient, renderWithClient, runningScan } from './helpers'
+import type { ScanStatus } from '../types'
+
+function Monitor() { const { data } = useScanStatus(); return <ScanSummary status={data} /> }
+
+it.each(['completed', 'completed_with_errors', 'cancelled', 'failed'] as const)('refreshes all cached results once on %s and keeps the completion visible', async (outcome) => {
+  const client = makeClient()
+  vi.spyOn(scanApi, 'getStatus').mockResolvedValue({ data: runningScan } as Awaited<ReturnType<typeof scanApi.getStatus>>)
+  const keys = [['stats'], ['shows', 'anime', 2], ['files', 3], ['file', 1], ['show', '1'], ['season', '1', 0], ['scanLocations'], ['trackRemovalPlan', 1]]
+  keys.forEach((key) => client.setQueryData(key, { before: true }))
+  client.setQueryData(['scanStatus'], runningScan)
+  const invalidate = vi.spyOn(client, 'invalidateQueries')
+  const view = renderWithClient(<Monitor />, client)
+  const finished: ScanStatus = { ...runningScan, is_running: false, outcome, files_scanned: 2, finished_at: '2026-09-08T16:01:00Z' }
+  await act(async () => { client.setQueryData(['scanStatus'], finished) })
+  await waitFor(() => expect(client.getQueryState(['stats'])?.isInvalidated).toBe(true))
+  keys.forEach((key) => expect(client.getQueryState(key)?.isInvalidated).toBe(true))
+  const count = invalidate.mock.calls.length
+  await act(async () => { client.setQueryData(['scanStatus'], { ...finished }) })
+  view.unmount()
+  renderWithClient(<Monitor />, client)
+  expect(invalidate).toHaveBeenCalledTimes(count)
+  expect(screen.getByRole('status')).toHaveTextContent(outcome === 'completed_with_errors' ? 'Scan completed with errors' : `Scan ${outcome}`)
+})
+
+it('shows bounded, expandable errors and Plex warnings after completion', async () => {
+  renderWithClient(<ScanSummary status={{ ...runningScan, outcome: 'completed_with_errors', is_running: false,
+    finished_at: '2026-09-08T16:01:00Z', error_count: 64, warning_count: 1,
+    errors: Array.from({ length: 64 }, (_, i) => `Unreadable file ${i}`), warnings: ['Plex unavailable; local scanning continues.'] }} />)
+  expect(screen.getByRole('status')).toHaveTextContent('Scan completed with errors')
+  await userEvent.click(screen.getByText('64 scan errors'))
+  expect(within(screen.getByRole('list', { name: 'Scan errors' })).getAllByRole('listitem')).toHaveLength(50)
+  expect(screen.getByText('Showing the first 50 errors.')).toBeVisible()
+  expect(screen.queryByText('Unreadable file 50')).not.toBeInTheDocument()
+  await userEvent.click(screen.getByText('1 scan warnings'))
+  expect(screen.getByText('Plex unavailable; local scanning continues.')).toBeVisible()
+})
+
+it('lets the user request a full scan of unchanged files', async () => {
+  vi.spyOn(mediaApi, 'getStats').mockResolvedValue({ data: {} } as Awaited<ReturnType<typeof mediaApi.getStats>>)
+  vi.spyOn(scanApi, 'getStatus').mockResolvedValue({ data: { ...runningScan, is_running: false, outcome: 'idle' } } as Awaited<ReturnType<typeof scanApi.getStatus>>)
+  const start = vi.spyOn(scanApi, 'start').mockResolvedValue({ data: runningScan } as Awaited<ReturnType<typeof scanApi.start>>)
+  renderWithClient(<DashboardPage />)
+  await userEvent.click(await screen.findByRole('checkbox', { name: 'Full scan' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Start Scan' }))
+  await waitFor(() => expect(start).toHaveBeenCalledWith({ incremental: false }))
+})

--- a/frontend/src/test/helpers.tsx
+++ b/frontend/src/test/helpers.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type { MediaFile, ScanStatus, UserSettings } from '../types'
+
+export function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity, gcTime: Infinity }, mutations: { retry: false } } })
+}
+export function renderWithClient(children: ReactNode, client = makeClient()) {
+  return { ...render(<QueryClientProvider client={client}>{children}</QueryClientProvider>), client }
+}
+export function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no })
+  return { promise, resolve, reject }
+}
+export const settings: UserSettings = {
+  audio_preferences: { require_english_non_anime: true, require_japanese_anime: true,
+    require_dual_audio_anime: true, check_default_track: true, preferred_codecs: [],
+    auto_fix_english_default_non_anime: false, audio_track_keep_languages: ['ja', 'und'] },
+  anime_detection: { use_plex_genres: true, anime_folder_keywords: ['anime'] },
+  file_extensions: ['.mkv'],
+}
+export const runningScan: ScanStatus = {
+  is_running: true, outcome: 'running', started_at: '2026-09-08T16:00:00Z', finished_at: null,
+  current_location: '/media', current_file: 'movie.mkv', files_scanned: 0, files_total: 2,
+  files_removed: 0, errors: [], warnings: [], error_count: 0, warning_count: 0,
+}
+export const mediaFile: MediaFile = {
+  id: 1, filename: 'movie.mkv', file_path: '/media/movie.mkv', episode_number: null, episode_title: null,
+  file_size: 1024, container_format: 'Matroska', duration_ms: 1000, last_scanned: '2026-09-08T16:00:00',
+  has_issues: false, issue_details: null,
+  edit_capabilities: { set_default_audio: true, remove_audio_tracks: true, default_audio_reason: null, track_removal_reason: null },
+  audio_tracks: [
+    { language: 'en', language_raw: 'eng' }, { language: 'ja', language_raw: 'jpn' },
+    { language: null, language_raw: null },
+  ].map((language, index) => ({ id: index + 1, track_index: index + 1, ...language,
+    codec: 'AAC', channels: 2, channel_layout: 'stereo', bitrate: null, is_default: index === 0, is_forced: false, title: null })),
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom/vitest'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(cleanup)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,6 +41,12 @@ export interface ScanStatus {
   current_file: string | null
   started_at: string | null
   errors: string[]
+  warnings: string[]
+  error_count: number
+  warning_count: number
+  files_removed: number
+  finished_at: string | null
+  outcome: 'idle' | 'running' | 'completed' | 'completed_with_errors' | 'cancelled' | 'failed'
 }
 
 // Audio track types

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: { environment: 'jsdom', setupFiles: ['./src/test/setup.ts'], restoreMocks: true },
+})


### PR DESCRIPTION
Settings previously saved on each keystroke from stale query data, production deep links returned 404, and completed scans or media actions left related UI totals stale. This PR completes those fixes and adds frontend regression coverage for the earlier classification and audio-removal changes.

- Keep immediate local preference drafts and save explicitly. Serialize requests, cancel older settings reads, update cache from successful responses, and preserve edits made during a pending save. Show saving, unsaved, success, and failure states.
- Serve the React app for production client routes while retaining missing-asset/API 404s and unsupported-method responses.
- Poll scan status across authenticated navigation and refresh stats, filtered lists, file/show/season details, locations, and track-removal plans once per completed/cancelled/failed scan. Use the same refresh helper for media actions and resets.
- Keep completed, completed-with-errors, cancelled, and failed summaries visible, with bounded expandable errors/warnings. Add an explicit Full scan control.
- Add Vitest/Testing Library tests for delayed and out-of-order responses, manual anime marking/unmarking (including movie layout), saved removal plans/manual overrides, resets, scan completion/cache refresh, bounded messages, and full scans. Run those tests in CI.

Validation: [CI run 34277881481](https://github.com/TheSoloGreen/TrackHound/actions/runs/34277881481) passed on this exact tree: **147 backend tests and 12 frontend regression tests**, TypeScript/production build, and all production container/Compose checks. The backend suite includes PostgreSQL historical upgrades/recovery, native MKV editing, and 18 direct-route/API/asset/method integration tests. Image publication was skipped for the draft PR.

**Dependency and merge order:** #42 → #43 → #44 → this PR, into `master`. This draft targets `fix/scan-correctness` for a focused diff. Preserve the parent ancestry or update dependent branches if using squash/rebase merges. No merge, image publication, or deployment has occurred.

`docs/IMPLEMENTATION_PROGRESS.md` records item-by-item coverage for all 16 existing issues and upgrade requirements. Back up the database with its matching encryption key before upgrading. Scan status and edit coordination still require one worker/container; restart-resumable jobs and multi-worker coordination remain future work.

Fixes #34, fixes #36, fixes #37, fixes #38. Completes frontend regression coverage for #35 and the full-scan control for #29.